### PR TITLE
Copies .gitignore from standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
 Gemfile.lock
 _site
+_build_pdf
 *.pdf
+*.epub
+.bundle/
+vendor/
+urls-sorted.txt
+urls.txt
+release.body
+*.orig
+node_modules/
+package-lock.json


### PR DESCRIPTION
Not sure if we need all of these, but ignoring bundle and vendor makes local builds easier  