### PR TITLE
link Dutch to live page not to repo in overview

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ The authoritative language for the standard is English, and the current version 
 
 | Language | Version | Latest release |
 |----------|---------|---------|
-| [Dutch](https://github.com/codefornl/community-translations-standard) | 0.8.0 | [0.8.0-nl-0.1.1](https://github.com/codefornl/community-translations-standard/releases/tag/0.8.0-nl-0.1.1) |
+| [Dutch](https://www.standaardvoorpubliekecode.nl) | 0.8.0 | [0.8.0-nl-0.1.1](https://github.com/codefornl/community-translations-standard/releases/tag/0.8.0-nl-0.1.1) |
 | [Spanish](es/index.md) | 0.2.1 | |
 
 ## Contributing


### PR DESCRIPTION
Sorry, to be consistent, I think the link needs to point at the live translation, not the repository