### PR TITLE
Change CHANGELOG to RELEASE_NOTES

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ These are the files that need to be translated before it is ready for review.
 - [CODE_OF_CONDUCT.md](https://github.com/publiccodenet/standard/blob/main/CODE_OF_CONDUCT.md)
 - [CONTRIBUTING.md](https://github.com/publiccodenet/standard/blob/main/CONTRIBUTING.md)
 - [GOVERNANCE.md](https://github.com/publiccodenet/standard/blob/main/GOVERNANCE.md)
-- [CHANGELOG.md](https://github.com/publiccodenet/standard/blob/main/CHANGELOG.md)
+- [RELEASE_NOTES.md](https://github.com/publiccodenet/standard/blob/main/RELEASE_NOTES.md)
 - [AUTHORS.md](https://github.com/publiccodenet/standard/blob/main/AUTHORS.md)
 - [standard-print.html](https://github.com/publiccodenet/standard/blob/main/standard-print.html)
 - [print-cover.html](https://github.com/publiccodenet/standard/blob/main/print-cover.html)

--- a/script/new-translation.sh
+++ b/script/new-translation.sh
@@ -51,7 +51,7 @@ glossary.md \
 CODE_OF_CONDUCT.md \
 CONTRIBUTING.md \
 GOVERNANCE.md \
-CHANGELOG.md \
+RELEASE_NOTES.md \
 AUTHORS.md \
 foreword-print.html \
 print-cover.html \


### PR DESCRIPTION
Since it was updated in https://github.com/standard-for-public-code/standard-for-public-code/pull/1054 we should update it here too.