### PR TITLE
Add swedish translation

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,6 +13,7 @@ The authoritative language for the standard is English, and the current version 
 | [Danish](da/index.md) | 0.2.1 | |
 | [Dutch](https://www.standaardvoorpubliekecode.nl) | 0.8.0 | [0.8.0-nl-0.1.1](https://github.com/codefornl/community-translations-standard/releases/tag/0.8.0-nl-0.1.1) |
 | [Spanish](es/index.md) | 0.2.1 | |
+| [Swedish](sv/index.md) | 0.8.1-development | |
 | [Traditional Chinese (Taiwan)](zh_Hant_TW/index.md) | 0.7.1 | |
 
 ## Contributing

--- a/sv/AUTHORS.md
+++ b/sv/AUTHORS.md
@@ -1,0 +1,49 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+---
+# Upphovspersoner
+
+## Översättning till svenska
+
+* Anton Wiklund, [Swedish Public Employment Service](https://arbetsformedlingen.se/)
+* Josef Andersson, [Agency for Digital Government](https://www.digg.se/)
+
+## Upphovspersoner till originaltexten
+
+* Alba Roza, [The Foundation for Public Code](https://publiccode.net/)
+* Anton Wiklund, [Swedish Public Employment Service](https://arbetsformedlingen.se/)
+* Arnout Engelen
+* Arnout Schuijff, The Foundation for Public Code
+* Audrey Tang, [digitalminister.tw](https://digitalminister.tw/)
+* Bastien Guerry, [DINUM](https://www.numerique.gouv.fr/dinum/)
+* Ben Cerveny, The Foundation for Public Code
+* Bert Spaan
+* Boris van Hoytema, The Foundation for Public Code
+* Charlotte Heikendorf
+* Claus Mullie, The Foundation for Public Code
+* David Barberi
+* Edo Plantinga, [Code For NL](https://codefor.nl/)
+* Elena Findley-de Regt, The Foundation for Public Code
+* Eric Herman, The Foundation for Public Code
+* Felix Faassen, The Foundation for Public Code
+* Floris Deerenberg
+* Jan Ainali, The Foundation for Public Code
+* Johan Groenen, Code For NL
+* Josef Andersson, [Agency for Digital Government](https://www.digg.se/)
+* Marcus Klaas de Vries
+* Mark van der Net, [Gemeente Amsterdam](https://www.amsterdam.nl/en/)
+* Martijn de Waal, [Amsterdam University of Applied Sciences (AUAS)](https://www.amsterdamuas.com/), Faculty of Digital Media and Creative Industries, Lectorate of Play & Civic Media
+* Matti Schneider
+* Mauko Quiroga
+* Maurice Hendriks, Gemeente Amsterdam
+* Maurits van der Schee, Gemeente Amsterdam
+* Mirjam van Tiel, The Foundation for Public Code
+* Ngô Ngọc Đức Huy
+* Oliver Brian
+* Paul Keller
+* Petteri Kivimäki, [Nordic Institute for Interoperability Solutions (NIIS)](https://niis.org)
+* Rasmus Frey, [OS2](https://www.os2.eu/)
+* Sky Bristol
+* Tamas Erkelens, Gemeente Amsterdam
+* Timo Slinger

--- a/sv/CODE_OF_CONDUCT.md
+++ b/sv/CODE_OF_CONDUCT.md
@@ -1,0 +1,20 @@
+# Uppförandekod
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2021-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
+
+Flera, men inte alla, av gemenskapens medlemmar kommer från offentliga eller professionella miljöer med uppförandekoder.
+Dokumentet anger förväntningar på alla gemenskapens medlemmar och på allt samspel, oavsett kommunikationskanal.
+
+Var här för att samarbeta.
+
+Var hänsynsfull, respektfull och tålmodig.
+
+Sträva efter att vara så konstruktiv som möjligt.
+
+För att framföra en synpunkt, skicka e-post till någon av våra frivilliga:
+
+* Anton Wiklund <antonwiklund91@gmail.com>
+* Johan Groenen <johan@tiltshift.nl>
+
+Om du vill bli frivillig, skicka en ändringsförfrågan där du lägger till dig i listan ovan.

--- a/sv/CONTRIBUTING.md
+++ b/sv/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Att bidra till standarden
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
+
+Tack för att du bidrar!
+
+Vi förstår att en standard som denna bara kan fastställas i samarbete med så många offentliga teknologer, beslutsfattare och intresserade personer som möjligt.
+Därför uppskattar vi dina synpunkter, välkomnar återkoppling och förbättringar av projektet, och är mycket öppna för samarbete.
+
+Vi välkomnar ärenden och ändringsförfrågningar från alla.
+Om du inte är bekväm med GitHub, delta gärna i nästa [gemenskapssamtal](https://community.standardforpubliccode.org/) och ge din återkoppling.
+
+## Problem, förslag och frågor i ärenden
+
+En övergripande översikt av planerad utveckling finns i [framtidsplanen](/docs/roadmap.md).
+Hjälp gärna utvecklingen genom att rapportera problem, föreslå ändringar och ställa frågor.
+För att göra detta kan du [skapa ett ärende på GitHub](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue) för projektet i [GitHub-ärenden för standarden för offentlig kod](https://github.com/standard-for-public-code/standard-for-public-code/issues).
+
+Eller delta i [diskussionerna](https://github.com/standard-for-public-code/standard-for-public-code/discussions).
+
+Du behöver inte ändra kod eller dokumentation för att bidra!
+
+## Dokumentation och kod i ändringsförfrågningar
+
+Om du vill lägga till dokumentation eller kod i något av våra projekt bör du göra en ändringsförfrågan.
+
+Om du aldrig har använt GitHub, kom igång med [Understanding the GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow) eller följ en av de utmärkta kostnadsfria interaktiva kurserna i [GitHub Skills](https://skills.github.com/) om att arbeta med GitHub och Markdown, den syntax som projektets dokumentation är skriven i.
+
+Projektet är licensierat under Creative Commons Zero v1.0 Universal, vilket i huvudsak innebär att projektet, tillsammans med dina bidrag, är i allmän egendom i alla jurisdiktioner där det är möjligt, och att alla kan göra vad de vill med det.
+
+### 1. Gör dina ändringar
+
+Bidrag bör [följa](docs/standard-for-public-code.html) de krav som anges i kriterierna i standarden för offentlig kod.
+Granskare kommer också att säkerställa att bidrag är i linje med [offentlig kods värden](foreword.md#offentlig-kods-värden).
+Vidare kommer de att granska att bidraget överensstämmer med [standarderna](#standarder-att-följa) och förblir sammanhängande med helheten.
+
+Projektet använder [GitFlow-grenmodellen och arbetsflödet](https://nvie.com/posts/a-successful-git-branching-model/).
+När du har skapat en avgrening av kodförrådet, se till att skapa en funktionsgren enligt GitFlow-modellen.
+
+Lägg till dina ändringar i incheckningar [med ett meddelande som förklarar dem](https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message).
+Om mer än en typ av ändring behövs, gruppera logiskt sammanhörande ändringar i separata incheckningar.
+Till exempel kan ändringar av blanksteg vara en separat incheckning från ändringar av textinnehåll.
+När du lägger till nya filer, välj filformat som enkelt kan granskas i en skillnadsjämförelse; till exempel är `.svg` att föredra framför ett binärt bildformat.
+Dokumentera val eller beslut du gör i incheckningsmeddelandet; detta gör det möjligt för alla att i framtiden ta del av dina val.
+
+Om du lägger till kod, se till att du har lagt till och uppdaterat relevant dokumentation och tester innan du skickar in din ändringsförfrågan.
+Se till att skriva tester som visar beteendet hos den nyligen tillagda eller ändrade koden.
+
+#### Tillämpligt regelverk
+
+Standarden för offentlig kod tillämpar för närvarande inget specifikt offentligt regelverk.
+
+#### Stil
+
+Standarden för offentlig kod strävar efter att [använda enkel engelska](criteria/use-plain-english.md) och vi har valt amerikansk engelska för stavning.
+Textinnehåll bör normalt följa en rad per mening, utan radbrytning, för att göra skillnadsjämförelser enklare att granska.
+Vi vill betona att det är viktigare att du gör ditt bidrag än att du oroar dig för stavning och typografi.
+Vi hjälper dig med det i vår granskningsprocess och har också en separat kvalitetskontroll innan vi [gör en ny utgåva](docs/releasing.md).
+
+#### Standarder att följa
+
+Följande standarder används av standarden för offentlig kod.
+Se till att dina bidrag är i linje med dem så att de kan sammanslås enklare.
+
+* [IETF RFC 2119](https://tools.ietf.org/html/rfc2119); för kravnivånyckelord
+* [Web Content Accessibility Guidelines 2.1](https://www.w3.org/WAI/WCAG22/quickref/?showtechniques=315#reading-level); för läsbarhet
+
+### 2. Ändringsförfrågan
+
+När du skickar in ändringsförfrågan, bifoga en beskrivning av problemet du försöker lösa och ärendenumret som ändringsförfrågan åtgärdar.
+Det föredras att varje ändringsförfrågan hanterar ett enskilt ärende där det är möjligt.
+I vissa fall kan en enda uppsättning ändringar lösa flera ärenden; i så fall, se till att lista alla åtgärdade ärendenummer.
+
+Öppna ändringsförfrågningar i **utkastläge** medan du fortfarande arbetar med dem.
+Utkast till ändringsförfrågningar gör det möjligt för styrgruppen och andra i gemenskapen att samarbeta, titta på och kommentera dina ändringar tidigt i processen.
+
+När du är nöjd med dina ändringar, markera ändringsförfrågan som **redo** så att den slutliga granskningsprocessen kan påbörjas.
+
+### 3. Förbättra
+
+Alla bidrag måste granskas av någon.
+
+Det kan hända att ditt bidrag kan sammanslås direkt av en styrgruppsledamot.
+Vanligtvis behöver dock en ny ändringsförfrågan vissa förbättringar innan den kan sammanslås.
+Andra bidragsgivare (eller hjälprobotar) kan ha återkoppling.
+Om så är fallet hjälper granskaren dig att förbättra din dokumentation och kod.
+
+Om din dokumentation och kod har godkänts i granskning, och en styrgruppsledamot bedömer att den är i linje med [framtidsplanen](docs/roadmap.md), sammanslås den i målgrenen av en styrgruppsledamot (som kan vara samma person som granskade koden).
+I annat fall tar styrgruppsledamoten upp det för styrgruppen att besluta om.
+
+### 4. Fira
+
+Dina idéer, din dokumentation och din kod har blivit en integrerad del av projektet.
+Du är den hjälte för fri- och öppen programvara vi behöver!
+
+Som gemenskap vill vi gärna ta med alla bidragsgivare i [`AUTHORS`](AUTHORS.md).
+Om ditt namn inte redan finns där, skicka gärna en ändringsförfrågan för att lägga till dig.
+Varje utgåva innehåller en genomgång för att kontrollera att alla nya bidragsgivare har omnämnts.
+Låt oss uttryckligen veta om du inte vill stå med.
+
+## Språk och översättningar
+
+Det auktoritativa språket för standarden för offentlig kod är engelska.
+
+Versioner på andra språk tillhandahålls av gemenskapen efter bästa förmåga.
+De följer inte nödvändigtvis den engelska versionen, eftersom saknade översättningar inte blockerar nya utgåvor.
+Du är välkommen att hjälpa till att underhålla befintliga och lägga till nya [gemenskapsöversättningar av standarden](https://github.com/standard-for-public-code/community-translations-standard).
+
+## Utgåvor
+
+Vi har särskild dokumentation för att skapa [nya utgåvor](/docs/releasing.md) och [beställa tryckta standarder](/docs/printing.md).
+
+För mer information om hur man använder och bidrar till projektet, läs [`README`](README.md).

--- a/sv/GOVERNANCE.md
+++ b/sv/GOVERNANCE.md
@@ -1,0 +1,101 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2024-2026 Standard for Public Code Authors, https://github.com/standard-for-public-code/standard-for-public-code/blob/develop/AUTHORS.md
+---
+# Styrning
+
+Standarden för offentlig kod är ett gemenskapsförvaltat projekt.
+
+## Principer
+
+Gemenskapen för standarden för offentlig kod har följande principer:
+
+- Öppenhet; så få begränsningar som möjligt för alla att anpassa standarden för offentlig kod till sitt sammanhang
+- Välkomnande och respektfullt; som gemenskap vill vi göra det enklare för nya användare att bli bidragsgivare
+- Insyn och tillgänglighet; ändringar av standarden för offentlig kod, dess styrning och all annan relaterad verksamhet görs öppet
+- Idéer och bidrag godtas utifrån hur väl de stämmer överens med projektets mål, omfattning och utformningsprinciper
+
+## Styrgrupp
+
+Gemenskapen för standarden för offentlig kod har en styrgrupp.
+
+### Sammansättning
+
+Varje aktiv bidragsgivare i gemenskapen kan begära att bli styrgruppsledamot genom att fråga styrgruppen.
+Styrgruppen röstar om saken (se omröstning nedan).
+
+De nuvarande ledamöterna är:
+
+- Claus Mullie
+- Johan Groenen (Tiltshift, Code for NL)
+- Rasmus Frey (OS2)
+- Josef Andersson (Digg)
+- [Matti Schneider](https://mattischneider.fr)
+- [Bastien Guerry](https://bzg.fr)
+- Anton Wiklund (Arbetsförmedlingen)
+
+I möjligaste mån bör ingen enskild organisation anställa en majoritet av styrgruppens ledamöter.
+
+### Ansvar
+
+Styrgruppens ledamöter är aktiva bidragsgivare som dagligen ansvarar för:
+
+- Sammanslagning av ändringsförfrågningar
+- Hantering av överträdelser av uppförandekoden
+
+Utöver den dagliga verksamheten har styrgruppen gemensamt ansvar för att:
+
+- Tillhandahålla teknisk riktning för kodbasen
+- Förvalta en framtidsplan och bidragsprinciper
+- Lösa utvecklingsfrågor eller konflikter mellan bidragsgivare
+- Hantera och planera utgåvor
+- Kontrollera åtkomsträttigheter till standarden för offentlig kods tillgångar såsom kodförråd, värdtjänster och projektkalendrar
+- Upprätthålla projektets uppdrag, vision, värderingar och omfattning
+- Förfina styrningen vid behov
+- Fatta beslut på kodbasnivå
+- Förvalta varumärket för standarden för offentlig kod
+- Hantera licens- och immaterialrättsändringar
+
+### Möten
+
+Styrgruppen sammanträder regelbundet.
+Dagordningen omfattar genomgång av framtidsplanen och frågor som nått ett dödläge.
+Avsikten med dagordningen är inte att granska eller godkänna alla programfixar.
+(Granskning och godkännande av programfixar sker genom den process som beskrivs i [CONTRIBUTING.md](CONTRIBUTING.md).)
+
+## Beslutsprocess
+
+Beslutsprocessen bygger på samtycke som standard och omröstning för vissa frågor.
+
+### Samtycke
+
+I gemenskapen innebär "samtycke" att om du bedömer att ett beslut är okontroversiellt kan du helt enkelt gå vidare och fatta det beslutet.
+Varje beslut som fattas på detta sätt anses ha stöd så länge ingen invänder.
+Självfallet måste du vara beredd att återställa ditt arbete om någon invänder.
+
+Om det råder osäkerhet kring ett beslut kan en styrgruppsledamot informera övriga i gruppen om att hen avser att fatta ett visst beslut.
+Om ingen ledamot invänder inom 96 timmar anses beslutet ha stöd.
+Om invändningar framförs och ingen lösning kan nås genom diskussion kan en ledamot begära omröstning med enkel majoritet, se nedan.
+
+### Omröstning
+
+Varje styrgruppsledamot har 1 röst.
+Alla röster protokollförs offentligt.
+
+Många av de dagliga förvaltningsuppgifterna kan hanteras genom samtyckesprocessen.
+Men följande frågor **måste** tas till omröstning:
+
+- Tillägg av en ledamot (enkel majoritet)
+- Avsättning av en ledamot (kvalificerad majoritet)
+- Ändring av styrningsreglerna (dokumentet) (kvalificerad majoritet)
+- Licens- och immaterialrättsändringar (inbegripet nya logotyper och ordmärken) (enkel majoritet)
+- Tillägg, arkivering eller borttagning av delprojekt (enkel majoritet)
+
+Med enkel majoritet avses att minst hälften av styrgruppens ledamöter har röstat för, och med kvalificerad majoritet två tredjedelar av styrgruppens ledamöter.
+
+## Uppförandekod
+
+Standarden för offentlig kods uppförandekod beskrivs i [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+Om den möjliga överträdelsen gäller en ledamot ska denne inte delta i omröstningen i ärendet.
+Sådana ärenden ska lyftas till styrgruppens kontaktperson, och styrgruppen kan välja att ingripa.

--- a/sv/LICENSE
+++ b/sv/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/sv/RELEASE_NOTES.md
+++ b/sv/RELEASE_NOTES.md
@@ -1,0 +1,274 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2025-2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+# script/release-body.sh expects VERSION in the first second-level header
+# script/update-release-notes-date.sh expects DATE-OF-RELEASE and a colon
+redirect_from:
+  - CHANGELOG
+---
+# Versionshistorik
+
+## Version 0.8.1
+
+28 april 2025: 🧑‍🤝‍🧑 Det artonde utkastet övergår till gemenskapsstyrning.
+
+* Projektet har övergått till en gemenskapsstyrningsmodell.
+  * Styrningsmodellen omfattar nu styrgrupp, sammansättning, ansvar, möten, beslutsprocess, samtycke, omröstning och uppförandekod.
+  * Webbplatsen finns nu på den nya domänen [https://www.standardforpubliccode.org/](https://www.standardforpubliccode.org/).
+  * SPDX-upphovsrättstext uppdaterad för alla projektfiler.
+* Tog bort valfritt krav i Dokumentera koden om lockande exempel.
+* Kriterietexterna har förenklats något för att bli lättare att förstå, med färre tekniska termer.
+* README-filen i kodförrådet har fått förbättrad dokumentation.
+* CHANGELOG döptes om till RELEASE_NOTES.
+* Förbättringar av utgåveriktlinjer.
+* Mindre textändringar för tydlighet och enhetlighet.
+
+## Version 0.8.0
+
+9 januari 2024: 🌐 Det sjuttonde utkastet särskiljer auktoritativa översättningar och artighetsöversättningar.
+
+* Förtydligar att utöver engelska kan fler auktoritativa språk användas.
+* Tillåter artighetsöversättningar som kanske inte är uppdaterade vid utgåvotillfället.
+* Lägger till vägledning om att ge utvecklare mandat att prioritera skyndsam granskning av bidrag.
+* Utökar vägledning om hur man bedömer att granskningar sker i rimlig tid.
+* Innehåller mindre textändringar för tydlighet och enhetlighet.
+
+## Version 0.7.1
+
+31 juli 2023: 💄 Det sextonde utkastet byter namn på ett kriterium och förtydligar hänvisningar till kod.
+
+* Kriteriet "Make the codebase reusable and portable" bytte namn från "Create reusable and portable code".
+* Lade till en ordlistepost för "Source Code".
+* Där "code" bara gällde "source code" hänvisas nu uttryckligen till "source code".
+* Förtydligande av "running code" som "software".
+* Mindre ändringar för att klargöra "code" kontra "codebase".
+* Förenklad vägledning till beslutsfattare i Paketera regelverk och källkod.
+* Förtydligande av avsnitten Hur du testar i Kodbasen ska vara lättfunnen och Gör kodbasen återanvändbar och portabel.
+* Lade till en checklista för kriterier och krav bland utgåveartefakterna.
+* Ökad automatisering av utgåveprocessen.
+
+## Version 0.7.0
+
+31 maj 2023: 📑 Det femtonde utkastet lägger till nya krav för dokumentation av granskningsfinansiering och förtydligar krav på granskningsprocessen.
+
+* Nytt krav att dokumentera vem som förväntas stå för granskningskostnaderna för bidrag.
+* Nytt krav att ha en kort beskrivning av kodbasen.
+* Ändrat fokus från bidragsefterlevnad av standarder till granskning av bidrag.
+* Lättade MÅSTE-krav till BÖR i Kodbasen ska vara lättfunnen.
+* Granskningsmallen finns nu i HTML-format.
+* Introduktionen omvandlad till förord.
+* Förbättrade riktlinjer för bidrag.
+* Förbättrad dokumentation av skript.
+
+## Version 0.6.0
+
+20 april 2023: 🔀 Det fjortonde utkastet lägger till nya krav för portabilitet och tester samt en inledning till varje kriterium.
+
+* Nytt krav i Gör kodbasen återanvändbar och portabel om att utvecklingen ska vara ett samarbete mellan flera parter.
+* Nytt krav i Gör kodbasen återanvändbar och portabel om beroende av en enskild leverantör.
+* Nytt krav i Använd kontinuerlig integrering om publicering av resultat för automatiserade tester.
+* Särskiljer de två säkerhetskraven så att det ena tydligt handlar om att tillhandahålla en metod och det andra om dokumentation.
+* Omformulerade krav för att fokusera på kodbasen snarare än bidragsgivarnas beteende.
+* Tog bort avsnitten Varför detta är viktigt och Vad detta inte omfattar; ersatte dem med en inledning i varje kriterium.
+* Lade till det generella avsnittet Vad detta inte omfattar i standardens introduktion.
+* Lade till vägledning för offentliga beslutsfattare om relaterade regelverk och licenskompatibilitet.
+* Lade till vägledning för utvecklare och formgivare om versionshantering av filer.
+* Förtydligade vägledning för utvecklare och formgivare om snabba svar och sökmotoroptimering.
+* Lade till Vidare läsning om tillgänglighet.
+* Anpassade kriterie-URL:er till kriterienamnen.
+* Förbättrad navigering i webbversionen.
+* Flyttade verktyg i avsnitten Vidare läsning till handledningen för gemenskapen.
+* Flyttade efterlevnads- eller certifieringsprocessen till [publiccode.net](https://publiccode.net).
+* Ändrade format på granskningsmallen för att underlätta uppdatering efter en ny utgåva.
+* Förbättrade texten på landningssidan och lade till länkar till relaterade resurser.
+* Lade till automatiserad stavningskontroll.
+* Mindre textändringar för tydlighet och enhetlighet.
+* Flyttade SPDX-rubriker till YAML-frontmatter.
+
+## Version 0.5.0
+
+25 januari 2023: 🎨 Det trettonde utkastet fokuserar på att dokumentera stilriktlinjer.
+
+* Justerade kodstilskravet så att det fokuserar på kodbasens stilguide snarare än bidragsgivarnas beteende.
+* Flyttade krav för kodbasnamn från Använd enkel engelska till Kodbasen ska vara lättfunnen.
+* Flyttade krav om att testa koden med hjälp av exempel från Dokumentera koden till Använd kontinuerlig integrering.
+* Delade upp krav om maskinellt testbara standarder för att förtydliga att öppenhet är viktigare än testbarhet.
+* Justerade testningen av sökbarhetskrav för att minska beroendet av sökmotoralgoritmer.
+* Mindre textändringar för tydlighet och enhetlighet.
+
+## Version 0.4.1
+
+5 december 2022: 📝 Det tolfte utkastet förtydligar dokumentation av mognad.
+
+* Dokumentera kodbasens mognad fokuserar på huruvida versioner av kodbasen är redo att användas.
+* Dokumentera kodbasens mognad kräver inte längre specifika etiketter för kodbaser som inte är redo att användas.
+* Granskningsflödesbilden genereras nu från ett format som är enklare att översätta.
+* Förbättrad vägledning i Hur du testar.
+* Lade till publiccode.yml-fil.
+* Lade till granskningsmall.
+* Enhetlig länkning av ordlistetermer.
+* Lade till rutiner och standarder att följa i CONTRIBUTING.
+* Lade till Matti Schneider bland upphovspersonerna.
+* Lade till återstående SPDX-rubriker i filer.
+* Ytterligare mindre textändringar för tydlighet.
+* Vissa hyperlänkar uppdaterade.
+* Flyttade exempel till [handledningen för gemenskapen](https://standard-for-public-code.github.io/community-implementation-guide-standard/).
+
+## Version 0.4.0
+
+7 september 2022: 🔭 Det elfte utkastet lägger till ett nytt sökbarhetskriterium.
+
+* Nytt kriterium: Kodbasen ska vara lättfunnen.
+* Förbättrat avsnittet Hur du testar för de flesta kriterier.
+* Nytt krav i Välkomna bidragsgivare om publicering av aktivitetsstatistik.
+* Tog bort överflödigt krav om portabel och återanvändbar kod.
+* Utökade definitionen av öppen licens till att omfatta både OSI- och FSF-godkända licenser.
+* Omformulerade FÅR-krav till att använda nyckelordet VALFRITT för tydlighet.
+* Uttalade avsikten att standarden ska uppfylla sina egna krav där tillämpligt. Lade till bedömning.
+* Lade till SPDX-licensidentifierare i filer.
+* Införde ny uppförandekod.
+* Förtydligade skillnaden mellan källkod och regelverkstext.
+* Omstrukturering av krav med punktlistor.
+* Uppmärksammar vikten av kodbasens modularitet för återanvändning.
+* Flyttade sökbarhetsrelaterade krav till det nya kriteriet.
+* Förtydligade rollen för icke-öppna standarder vid användning i en kodbas.
+* Ytterligare vägledning om beroenden vid byggtid och körtid.
+* Lade till framtidsplan för utvecklingen av standarden för offentlig kod.
+* Uppdaterade strukturen i AUTHORS-filen.
+* Lade till Audrey Tang bland upphovspersonerna.
+* Lade till en lista med kriterier i tryckversionen.
+* Förtydligade vad standarden avser med beslutsfattare, chefer, utvecklare och formgivare.
+* Ytterligare mindre textändringar för tydlighet.
+* Vissa hyperlänkar uppdaterade.
+
+## Version 0.3.0
+
+23 maj 2022: 🗎 Det tionde utkastet stärker dokumentation och lokalisering.
+
+* Krav på lokalisering gjordes uttryckligt i Gör kodbasen återanvändbar och portabel.
+* Dokumentation av styrning ändrat från BÖR till MÅSTE.
+* Ersatte det subjektiva (och svårtestade) kravet "bidrag MÅSTE vara små" med krav på att i riktlinjerna dokumentera förväntningar på bidrag och fokus på enskilda ärenden.
+* Gemenskapsöversättningar länkas nu i sidfoten.
+* Återställde "Replace BPMN svg with Mermaid flowchart".
+* Många mindre förtydliganden av språk och förenklingar av meningar.
+* Vissa hyperlänkar uppdaterade.
+
+## Version 0.2.3
+
+15 mars 2022: 📜 Det nionde utkastet tillåter engelska sammanfattningar för regelverk som saknar officiell översättning.
+
+* Lättade kriteriet Använd enkel engelska genom ett nytt krav: medföljande regelverk utan engelsk version får ha en sammanfattning på engelska istället för full översättning.
+* Tillåter på motsvarande sätt engelska sammanfattningar för regelverk utan tillgänglig engelsk version i Paketera regelverk och källkod.
+* Förtydligar att termen "policy" innefattar processer som påverkar utveckling och driftsättning i Paketera regelverk och källkod.
+* Betonar återanvändbarhet även av delar av lösningarna i Gör kodbasen återanvändbar och portabel.
+* Utökade vägledning till utvecklare och formgivare i Gör kodbasen återanvändbar och portabel om driftsättning på slutna plattformar.
+* Nyanserade vägledningen om icke-engelska termer under Chefer i Använd enkel engelska.
+* Bytte processdiagrammet för ändringsförfrågningar från BPMN till Mermaid för att underlätta [gemenskapsöversättningar](https://github.com/standard-for-public-code/community-translations-standard).
+* Lade till Maurice Hendriks bland upphovspersonerna.
+* Lade till OpenApi Specification i Vidare läsning.
+* Förtydligade tillskrivningarna i avsnitten Vidare läsning.
+* Ytterligare mindre textändringar för tydlighet.
+
+## Version 0.2.2
+
+29 november 2021: 🏛 Det åttonde utkastet erkänner att regelverk som verkställs som kod kanske inte är på engelska.
+
+* Dokumenterade undantag till "All code MUST be in English" där regelverk tolkas som kod.
+* Lade till FÅR-krav angående e-postadresser för incheckare i Upprätthåll versionshantering.
+* Utökade vägledning till beslutsfattare i Paketera regelverk och källkod.
+* Utökade vägledning till utvecklare och formgivare i Använd en enhetlig stil.
+* Lade till "Different contexts" i ordlistan.
+* Lade till Mauko Quiroga och Charlotte Heikendorf bland upphovspersonerna.
+* Lade till Digital Public Goods-godkännandemärke.
+* Lade till "nästa"- och "föregående"-länkar på kriteriesidorna i webbversionen.
+* Lade till Open Standards-principer i Vidare läsning.
+* Lade till Definition of plain language i Vidare läsning.
+* Flyttade hänvisningen till Semantic Versioning Specification i Vidare läsning.
+* Förtydligade att publiccode.yml är ett exempel på en maskinläsbar metadatabeskrivning.
+* Ändrade "your codebase" och "your organization" till mindre possessiva former.
+* Ytterligare mindre textändringar för tydlighet.
+* Lade till instruktioner för att skapa en tryckversion.
+
+## Version 0.2.1
+
+1 mars 2021: 🧽 Det sjunde utkastet gör mindre städning efter version 0.2.0.
+
+* Nytt BÖR-krav om distribuerat versionshanteringssystem, med motivering.
+* Striktare krav på återkoppling för avvisade bidrag jämfört med godkända.
+* Anger att upphovsrätts- och licensmeddelanden även bör vara maskinläsbara.
+* Vägledning om hur man testar att meddelanden är maskinläsbara.
+* Förtydligade vägledning för rullande utgåvor.
+* Förtydligade definitionen av versionshantering i ordlistan.
+* Lade till Vidare läsning om att uppmuntra bidrag, SPDX, Git och granskning av bidrag.
+* Lade till länkar till videor om konceptet offentlig kod.
+* Uppdaterade BPMN-länk.
+* Minskade länkduplicering.
+* Lade till Alba Roza och Ngô Ngọc Đức Huy bland upphovspersonerna.
+* Ytterligare mindre textändringar för tydlighet.
+
+## Version 0.2.0
+
+26 oktober 2020: 🎊 Det sjätte utkastet delar upp ett krav och tillför tydlighet.
+
+* Delade upp kriteriet "Welcome contributions" i "Make contributing easy" och "Welcome contributors".
+* Döpte om kriteriet "Pay attention to codebase maturity" till "Document codebase maturity".
+* Ändrade MÅSTE till BÖR för kravet att kodbasen ska användas av flera parter.
+* Lade till FÅR INTE-krav angående överlåtelse av upphovsrätt.
+* Förtydligade konfigurationens roll i kravet på återanvändbar kod.
+* Ordlistetillägg: continuous integration, policy, repository och version control.
+* Ersatte hänvisningar till "städer" med "offentliga organisationer".
+* Förtydligade aspekter av känslig kod genom att dela upp krav för bidragsgivare och granskare i egna punkter.
+* Utökade Vidare läsning och vägledning till beslutsfattare, utvecklare och formgivare.
+* Lade till Felix Faassen och Arnout Engelen bland upphovspersonerna.
+* Ytterligare mindre textändringar för tydlighet.
+
+## Version 0.1.4
+
+27 november 2019: 🧹 Det femte utkastet består mestadels av ytterligare mindre korrigeringar.
+
+* Länkade License.md-filen.
+* Lade till Sky Bristol, Marcus Klaas de Vries och Jan Ainali bland upphovspersonerna.
+* Mer enhetlig interpunktion, särskilt i punktlistor.
+* Några mindre textändringar för tydlighet.
+
+## Version 0.1.3
+
+8 oktober 2019: 🍂 Det fjärde utkastet åtgärdar bara mindre saker inför höststädningen.
+
+* Döpte om "continuous delivery" till "continuous integration".
+* Hänvisar till riktlinjer för tillgänglighet i språkstandarden.
+* En mängd stil- och enhetlighetskorrigeringar.
+
+## Version 0.1.2
+
+22 augusti 2019: 🌠 Det tredje utkastet fokuserar på bättre text och tar emot bidrag från gemenskapen.
+
+* Med flera fantastiska nya bidragsgivare kommer en uppdaterad upphovspersonslista.
+* Alla länkar använder nu HTTPS.
+* Allmän korrekturläsning, förtydliganden av formuleringar och rättade stavfel.
+* Uppdaterade kriterier:
+  * Krav på återanvändning i olika sammanhang
+  * Rekommendation om uttrycklig versionshantering
+  * Rekommendation om flerpartsutveckling
+  * Rekommendation om licensrubriker i filer
+  * Rekommendation om sårbarhetsrapportering
+  * Rekommendation om uttrycklig dokumentation av styrning
+
+## Version 0.1.1
+
+9 maj 2019: 🤔 Det andra utkastet rättar några grundläggande förbiseenden och en mängd stavfel.
+
+* Tog bort hänvisningar till Foundation for Public Code, eftersom namnbyte behövdes i samband med ombildningen till förening.
+* Uppdaterade introduktionen.
+* Uppdaterade ordlistan.
+* Lade till uppförandekoden.
+* Vi har rekommenderat att använda publiccode.yml-standarden för enklare återanvändning.
+
+## Version 0.1.0
+
+16 april 2019: 🎉 Det första utkastet är klart, helt nytt och med fräscha idéer.
+
+* 14 kriterier med krav och hur de omsätts i praktiken.
+* En introduktion med övergripande bakgrund, vad denna standard är och hur Foundation for Public Code kommer att använda den.
+
+Denna första version togs fram tillsammans med Amsterdam University of Applied Sciences och City of Amsterdam som en del av projektet [Smart Cities? Public Code!](https://smartcities.publiccode.net/).

--- a/sv/criteria/bundle-policy-and-source-code.md
+++ b/sv/criteria/bundle-policy-and-source-code.md
@@ -1,0 +1,57 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 2
+title: "Paketera regelverk och källkod"
+redirect_from:
+  - criteria/bundle-policy-and-code
+---
+# Paketera regelverk och källkod
+
+Tillgång till både [källkod](../glossary.md#källkod) och dokumentation av [regelverk](../glossary.md#regelverk) ger byggstenar för vem som helst att införa kodbasen i sitt lokala sammanhang eller att bidra till [kodbasens](../glossary.md#kodbas) fortsatta utveckling.
+
+Att förstå sakområdet och dess regelverk är grundläggande för att förstå vilka problem en kodbas försöker lösa och hur den löser dem.
+
+För att kunna bedöma om en kodbas ska användas i ett nytt sammanhang behöver en organisation förstå vilka processförändringar den behöver göra eller hur den kan bidra med ytterligare konfigurerbarhet till den befintliga lösningen för att anpassa den till det nya sammanhanget.
+
+## Krav
+
+* Kodbasen MÅSTE innehålla det regelverk som källkoden bygger på.
+* Om ett regelverk bygger på källkod MÅSTE den källkoden ingå i kodbasen, såvida den inte används för att upptäcka bedrägerier.
+* Regelverk BÖR tillhandahållas i maskinläsbara och entydiga format.
+* Tester för [kontinuerlig integrering (CI)](../glossary.md#kontinuerlig-integrering) BÖR verifiera att källkoden och regelverket verkställs på ett sammanhängande sätt.
+
+## Test
+
+* Bekräfta med en tjänsteperson att de regelverk källkoden bygger på ingår.
+* Bekräfta med en tjänsteperson att den källkod som regelverket bygger på ingår.
+* Kontrollera om regelverket kan tolkas maskinellt.
+* Kontrollera att testerna för kontinuerlig integrering lyckas för både källkod och regelverk.
+
+## Offentliga beslutsfattare behöver:
+
+* Samarbeta med utvecklare och formgivare för att säkerställa att det inte finns skillnader mellan regelverkskod och källkod.
+* Tillhandahålla relevanta regelverkstexter som ska ingå i [kodförrådet](../glossary.md#kodförråd), samt en engelsk sammanfattning om texten inte finns tillgänglig på engelska. Ta med standarder som er organisation har valt att följa och alla organisatoriska processer som påverkar utvecklingen eller driftsättningssammanhanget för kodbasen i er organisation.
+* Tillhandahålla hänvisningar och länkar till texter som stödjer regelverken.
+* Dokumentera regelverk i format som är entydiga och maskinläsbara, såsom de som publicerats av [Object Management Group](https://www.omg.org/spec/).
+* Spåra ändringar i regelverk med [samma versionshantering](maintain-version-control.md) och dokumentation som används för att spåra ändringar i källkod.
+* Hålla er regelbundet uppdaterade om hur källkoden i kodbasen har förändrats och om den fortfarande överensstämmer med [regelverkets intentioner](document-codebase-objectives.md).
+* Ta med relevanta regelverk som påverkar gemenskapen, kodbasen och utvecklingen, däribland rättsliga skyldigheter som [dataskyddsförordningen](https://eur-lex.europa.eu/eli/reg/2016/679/oj) eller [EU:s tillgänglighetsdirektiv för webben](https://ec.europa.eu/digital-single-market/en/web-accessibility), eller rättighetsregelverk, som en offentlig organisations åtagande om lika möjligheter.
+
+## Chefer behöver:
+
+* Se till att beslutsfattare, utvecklare och formgivare är delaktiga och sammankopplade genom hela utvecklingsprocessen.
+* Säkerställa att beslutsfattare, utvecklare och formgivare arbetar mot samma mål.
+
+## Utvecklare och formgivare behöver:
+
+* Bekanta er med den notation för processmodellering som beslutsfattarna i er organisation använder.
+* Arbeta tillsammans med beslutsfattare för att säkerställa att det inte finns skillnader mellan regelverkskod och källkod.
+* Ge återkoppling om hur regelverksdokumentation kan tydliggöras.
+
+## Vidare läsning
+
+* [Business Process Model and Notation](https://en.wikipedia.org/wiki/Business_Process_Model_and_Notation) på Wikipedia.
+* [BPMN Quick Guide](https://www.bpmnquickguide.com/view-bpmn-quick-guide/) av Trisotech.
+* [Decision Model and Notation](https://en.wikipedia.org/wiki/Decision_Model_and_Notation) på Wikipedia.
+* [Case Management Model Notation](https://en.wikipedia.org/wiki/CMMN) på Wikipedia.

--- a/sv/criteria/code-in-the-open.md
+++ b/sv/criteria/code-in-the-open.md
@@ -1,0 +1,48 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 1
+title: "Utveckla öppet"
+---
+# Utveckla öppet
+
+Att utveckla öppet förbättrar insynen, höjer [källkodens](../glossary.md#källkod) kvalitet, gör källkoden enklare att granska och möjliggör samarbete.
+
+Tillsammans skapar detta fler möjligheter för medborgare att förstå hur programvara och [regelverk](../glossary.md#regelverk) påverkar deras kontakt med en offentlig organisation.
+
+## Krav
+
+* All källkod för programvara som används (såvida den inte används för att upptäcka bedrägerier) MÅSTE vara publicerad och allmänt tillgänglig.
+* All källkod för regelverk som används (såvida den inte används för att upptäcka bedrägerier) MÅSTE vara publicerad och allmänt tillgänglig.
+* Kodbasen FÅR INTE innehålla känslig information om användare, deras organisation eller tredje parter.
+* Källkod som för närvarande inte används (såsom nya versioner, förslag eller äldre versioner) BÖR publiceras.
+* Att dokumentera vilken källkod eller vilket regelverk som ligger till grund för en specifik kontakt som [allmänheten](../glossary.md#allmänheten) kan ha med en organisation är VALFRITT.
+
+## Test
+
+* Bekräfta att källkoden för varje version som för närvarande används är publicerad på internet där den kan ses utanför den ursprungliga bidragande organisationen och utan behov av någon form av autentisering eller auktorisering.
+* Bekräfta att [kodbasens](../glossary.md#kodbas) filer och incheckningshistorik inte innehåller känslig information.
+* Kontrollera om källkod som för närvarande inte används har publicerats.
+
+## Offentliga beslutsfattare behöver:
+
+* Utveckla regelverk öppet.
+* Prioritera öppna regelverk som möjliggör insyn.
+
+## Chefer behöver:
+
+* Bygga upp en kultur som omfamnar öppenhet, lärande och återkoppling.
+* Samarbeta med externa leverantörer och frilansare genom att arbeta öppet.
+
+## Utvecklare och formgivare behöver:
+
+* I egenskap av granskare kontrollera vid varje incheckning att innehållet inte innehåller känslig information såsom konfigurationer, användarnamn eller lösenord, publika nycklar eller andra riktiga behörighetsuppgifter som används i produktionssystem.
+* Separera tydligt data och källkod för att uppfylla kravet om känslig information ovan.
+
+## Vidare läsning
+
+* [Coding in the open](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/) av UK Government Digital Service.
+* [When code should be open or closed](https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed) av UK Government Digital Service.
+* [Security considerations when coding in the open](https://www.gov.uk/government/publications/open-source-guidance/security-considerations-when-coding-in-the-open) av UK Government Digital Service.
+* [Deploying software regularly](https://www.gov.uk/service-manual/technology/deploying-software-regularly) av UK Government Digital Service.
+* [How GDS uses GitHub](https://gdstechnology.blog.gov.uk/2014/01/27/how-we-use-github/) av UK Government Digital Service.

--- a/sv/criteria/document-codebase-maturity.md
+++ b/sv/criteria/document-codebase-maturity.md
@@ -1,0 +1,52 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 16
+title: "Dokumentera kodbasens mognad"
+redirect_from:
+    - criteria/advertise-maturity
+    - criteria/document-maturity
+---
+# Dokumentera kodbasens mognad
+
+Att tydligt beskriva [kodbasens](../glossary.md#kodbas) mognad hjälper andra att avgöra om de ska använda och bidra till den.
+Mognaden hos en kodbasversion omfattar också mognaden hos dess beroenden.
+Att förstå hur en kodbas har utvecklats är nyckeln till att förstå kodbasen och hur man bidrar till den.
+
+## Krav
+
+* Kodbasen MÅSTE vara versionshanterad.
+* Kodbasen MÅSTE tydligt dokumentera huruvida det finns versioner av kodbasen som är redo att användas.
+* Kodbasversioner som är redo att användas MÅSTE bara bero på versioner av andra kodbaser som också är redo att användas.
+* Kodbasen BÖR innehålla en sammanfattning av ändringar från version till version, till exempel i `CHANGELOG`-filen.
+* Metoden för att tilldela versionsidentifierare BÖR vara dokumenterad.
+* Det är VALFRITT att använda semantisk versionering.
+
+## Test
+
+* Bekräfta att kodbasen har en dokumenterad strategi för versionering.
+* Bekräfta att det är uppenbart för beslutsfattare, chefer, utvecklare och formgivare huruvida kodbasen har versioner som är redo att användas.
+* Bekräfta att versioner av kodbasen som är redo att användas inte beror på versioner av andra kodbaser som inte är redo att användas.
+* Kontrollera att kodbasens versioneringsschema är dokumenterat och följs.
+* Kontrollera att det finns en sammanfattning av ändringar.
+
+## Offentliga beslutsfattare behöver:
+
+* Förstå att all [källkod](../glossary.md#källkod) som utvecklas behöver testas och förbättras innan den kan tas i bruk när ni utvecklar [regelverk](../glossary.md#regelverk).
+* Överväga att versionera regelverksändringar, särskilt när de leder till nya versioner av källkoden.
+
+## Chefer behöver:
+
+* Se till att tjänster bara förlitar sig på kodbasversioner med lika eller högre mognad än tjänsten. Använd till exempel inte en betaversion av en kodbas i en produktionstjänst.
+
+## Utvecklare och formgivare behöver:
+
+* Se till att kodbasens versioneringsmetod följs vid alla utgåvor.
+
+## Vidare läsning
+
+* [Semantic Versioning Specification](https://semver.org/) som används av många kodbaser för att märka versioner.
+* [Software release life cycle](https://en.wikipedia.org/wiki/Software_release_life_cycle)
+* [The Development Status key](https://yml.publiccode.tools/schema.core.html#key-developmentstatus) i publiccode.yml-standarden.
+* [Service Design and Delivery Process](https://www.digital.gov.au/policy/digital-experience/toolkit/service-design-and-delivery-process) av Australian Digital Transformation Agency.
+* [Service Manual on Agile Delivery](https://www.gov.uk/service-manual/agile-delivery) av UK Government Digital Service.

--- a/sv/criteria/document-codebase-objectives.md
+++ b/sv/criteria/document-codebase-objectives.md
@@ -1,0 +1,41 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 8
+title: "Dokumentera kodbasens mål"
+redirect_from:
+  - criteria/document-objectives
+---
+# Dokumentera kodbasens mål
+
+Att tydligt dokumentera [kodbasens](../glossary.md#kodbas) mål kommunicerar dess syfte.
+Det hjälper intressenter och bidragsgivare att avgränsa utvecklingen av kodbasen.
+Målen ger också ett enkelt sätt för människor att avgöra om kodbasen, eller en av dess moduler, är intressant för dem nu eller i framtiden.
+
+## Krav
+
+* Kodbasen MÅSTE dokumentera sina mål, till exempel genom ett uppdrag och en målbeskrivning, på ett sätt som är begripligt för utvecklare och formgivare så att de kan använda eller bidra till kodbasen.
+* Kodbasens dokumentation BÖR tydligt beskriva kopplingarna mellan [regelverkets](../glossary.md#regelverk) mål och kodbasens mål.
+* Att dokumentera kodbasens mål för [allmänheten](../glossary.md#allmänheten) är VALFRITT.
+
+## Test
+
+* Bekräfta att kodbasens dokumentation innehåller kodbasens mål, uppdrag eller målbeskrivning.
+* Kontrollera om det finns beskrivningar av kopplingarna mellan regelverkets mål och kodbasens mål.
+
+## Offentliga beslutsfattare behöver:
+
+* Lägga till regelverkets mål i kodbasens dokumentation, till exempel i `README`-filen.
+* Se till att alla era kodbasmål har länkar eller hänvisningar till regelverksdokumentation som lagts till för att uppfylla kriteriet [Paketera regelverk och källkod](bundle-policy-and-source-code.md).
+
+## Chefer behöver:
+
+* Lägga till organisatoriska och verksamhetsmässiga mål i kodbasens dokumentation, till exempel i `README`-filen.
+
+## Utvecklare och formgivare behöver:
+
+* Lägga till mål för teknik och formgivning i kodbasens dokumentation, till exempel i `README`-filen.
+
+## Vidare läsning
+
+* [How to write project objectives](http://grouper.ieee.org/groups/802/3/RTPGE/public/may12/hajduczenia_01_0512.pdf) av Marek Hajduczenia.

--- a/sv/criteria/document-the-code.md
+++ b/sv/criteria/document-the-code.md
@@ -1,0 +1,54 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 9
+title: "Dokumentera koden"
+redirect_from:
+  - criteria/documenting
+---
+# Dokumentera koden
+
+Väldokumenterad [källkod](../glossary.md#källkod) gör det lättare att förstå vad källkoden gör och hur den används.
+Dokumentation är avgörande för att människor ska kunna börja använda [kodbasen](../glossary.md#kodbas).
+Den gör det också enklare att bidra till kodbasen.
+
+## Krav
+
+* All funktionalitet MÅSTE beskrivas på ett tydligt språk. Målgruppen är de som förstår kodbasens syfte.
+* Dokumentationen MÅSTE innehålla en beskrivning av hur programvaran installeras och körs.
+* Dokumentationen MÅSTE innehålla exempel som visar den viktigaste funktionaliteten.
+* Dokumentationen BÖR innehålla en översikt som är lätt att förstå för en bred publik. Målgruppen omfattar [allmänheten](../glossary.md#allmänheten) och journalister.
+* Dokumentationen BÖR innehålla ett avsnitt som beskriver hur man installerar och kör en fristående version av programvaran. Det kan inbegripa en testdatamängd.
+* Dokumentationen BÖR innehålla exempel för all funktionalitet.
+* Dokumentationen BÖR beskriva nyckelkomponenter eller moduler och deras inbördes relationer. Det kan till exempel göras som ett övergripande arkitekturdiagram.
+* Det BÖR finnas tester för [kontinuerlig integrering](../glossary.md#kontinuerlig-integrering) av dokumentationens kvalitet.
+
+## Test
+
+* Bekräfta att andra intressenter finner dokumentationen tydlig och begriplig. Intressenterna bör omfatta yrkesverksamma från andra offentliga organisationer och allmänheten.
+* Bekräfta att dokumentationen beskriver hur källkoden installeras och körs.
+* Bekräfta att dokumentationen innehåller exempel på nyckelfunktionaliteten.
+* Kontrollera med medlemmar av allmänheten och journalister om de kan förstå översikten.
+* Kontrollera att instruktionerna för att installera och köra en fristående version av källkoden resulterar i ett fungerande system.
+* Kontrollera att dokumenterad funktionalitet innehåller exempel.
+* Kontrollera att dokumentationen innehåller ett övergripande arkitekturdiagram eller liknande.
+* Kontrollera att dokumentationskvaliteten är en del av integreringstestningen. Kontrollera till exempel att dokumentation genereras korrekt och att länkar och bilder testas.
+
+## Offentliga beslutsfattare behöver:
+
+* Hålla er regelbundet uppdaterade om hur den kod i kodbasen som inte rör regelverk har förändrats.
+* Ge återkoppling om hur dokumentation som inte rör regelverk kan göras tydligare.
+
+## Chefer behöver:
+
+* Prova att använda kodbasen så att ni kan ge återkoppling. Det kan förbättra hur [regelverket](../glossary.md#regelverk) och källkoden dokumenteras. Räcker till exempel dokumentationen för att övertyga en chef hos en annan offentlig organisation att använda kodbasen?
+* Se till att ni förstår kodbasens regelverk, källkod och dokumentation.
+
+## Utvecklare och formgivare behöver:
+
+* Hålla er regelbundet uppdaterade om hur de delar av kodbasen som inte är källkod har förändrats.
+* Ge återkoppling om hur dokumentation som inte avser källkod kan göras tydligare.
+
+## Vidare läsning
+
+* [Documentation guide](https://www.writethedocs.org/guide/) av Write the Docs.

--- a/sv/criteria/index.md
+++ b/sv/criteria/index.md
@@ -1,0 +1,12 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 0
+---
+# Kriterier
+
+{% assign sorted = site.pages | sort:"order" %}
+
+{% for page in sorted %}{% if page.dir == "/sv/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
+
+1. [{{page.title}}]({{page.url | relative_url}}){% endif%}    {% endif%}  {% endif%}{% endfor %}

--- a/sv/criteria/maintain-version-control.md
+++ b/sv/criteria/maintain-version-control.md
@@ -1,0 +1,61 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 6
+title: "Upprätthåll versionshantering"
+redirect_from:
+  - criteria/version-control-and-history
+---
+# Upprätthåll versionshantering
+
+[Versionshantering](../glossary.md#versionshantering) innebär att spåra ändringar i [källkoden](../glossary.md#källkod) och andra filer i [kodbasen](../glossary.md#kodbas) över tid.
+Det gör det möjligt att upprätthålla en strukturerad dokumentation av kodbasens historik.
+Det är avgörande för storskaligt samarbete, eftersom det gör det möjligt för utvecklare att arbeta med ändringar parallellt och hjälper framtida utvecklare att förstå anledningarna till ändringar.
+
+## Krav
+
+* Alla filer i kodbasen MÅSTE vara versionshanterade.
+* Alla beslut MÅSTE dokumenteras i incheckningsmeddelanden.
+* Varje incheckningsmeddelande MÅSTE länka till diskussioner och ärenden där det är möjligt.
+* Kodbasen BÖR förvaltas i ett distribuerat versionshanteringssystem.
+* Riktlinjer för bidrag BÖR kräva att bidragsgivare grupperar sammanhörande ändringar i incheckningar.
+* Underhållsansvariga BÖR märka utgivna versioner av kodbasen, till exempel med revisionsetiketter eller textetiketter.
+* Riktlinjer för bidrag BÖR uppmuntra filformat där ändringarna inuti filerna enkelt kan ses och förstås i versionshanteringssystemet.
+* Det är VALFRITT för bidragsgivare att signera sina incheckningar och ange en e-postadress, så att framtida bidragsgivare kan kontakta tidigare bidragsgivare med frågor om deras arbete.
+
+## Test
+
+* Bekräfta att kodbasen förvaltas med versionshantering med hjälp av programvara som Git.
+* Granska incheckningshistoriken och bekräfta att alla incheckningsmeddelanden förklarar varför ändringen gjordes.
+* Granska incheckningshistoriken och bekräfta att incheckningsmeddelanden där det är möjligt hänvisar till var diskussionen om ändringen fördes (med en webbadress).
+* Kontrollera om versionshanteringssystemet är distribuerat.
+* Granska incheckningshistoriken och kontrollera att sammanhörande ändringar grupperats i enlighet med riktlinjerna för bidrag.
+* Kontrollera att det är möjligt att nå en specifik version av kodbasen, till exempel genom en revisionsetikett eller en textetikett.
+* Kontrollera att filformaten som används i kodbasen är textformat där det är möjligt.
+
+## Offentliga beslutsfattare behöver:
+
+* Se till att dokumentationen tydligt beskriver följande om en ny version av kodbasen skapas på grund av en ändring i [regelverket](../glossary.md#regelverk):
+  * vad regelverksändringen innebär,
+  * hur den har förändrat kodbasen.
+
+Till exempel skulle tillägg av en ny sökandekategori i en kodbas som hanterar tillståndsgivning betraktas som en regelverksändring.
+
+## Chefer behöver:
+
+* Stödja beslutsfattare, utvecklare och formgivare i att vara tydliga med vilka förbättringar de gör i kodbasen. Att göra förbättringar är inte en kommunikationsrisk.
+
+## Utvecklare och formgivare behöver:
+
+* Se till att alla filer som krävs för att förstå koden, bygga och driftsätta finns i versionshanteringssystemet.
+* Skriva tydliga incheckningsmeddelanden så att det är lätt att förstå varför incheckningen gjordes.
+* Märka olika versioner så att det är lätt att nå en specifik version, till exempel med revisionsetiketter eller textetiketter.
+* Skriva tydliga incheckningsmeddelanden så att versioner kan jämföras på ett meningsfullt sätt.
+* Arbeta med beslutsfattare för att beskriva hur källkoden uppdaterades efter en regelverksändring.
+
+## Vidare läsning
+
+* [Producing OSS: Version Control Vocabulary](https://producingoss.com/en/vc.html#vc-vocabulary) av Karl Fogel.
+* [Maintaining version control in coding](https://www.gov.uk/service-manual/technology/maintaining-version-control-in-coding) av UK Government Digital Service.
+* [GitHub Skills](https://skills.github.com/) av GitHub för att lära sig använda GitHub eller fräscha upp sina kunskaper.
+* [Git Cheat Sheet](https://education.github.com/git-cheat-sheet-education.pdf) av GitHub, en lista med de vanligaste git-kommandona.

--- a/sv/criteria/make-contributing-easy.md
+++ b/sv/criteria/make-contributing-easy.md
@@ -1,0 +1,49 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 5
+title: "Gör det enkelt att bidra"
+---
+# Gör det enkelt att bidra
+
+För att utveckla bättre, mer tillförlitlig och funktionsrik programvara behöver användare kunna åtgärda problem, lägga till funktioner och hantera säkerhetsproblem i den delade [kodbasen](../glossary.md#kodbas).
+
+En delad digital infrastruktur gör det enklare att göra gemensamma bidrag.
+Ju mindre ansträngning det krävs för att göra bidrag som accepteras av kodbasen, desto troligare är det att användare blir bidragsgivare.
+
+## Krav
+
+* Kodbasen MÅSTE ha en offentlig ärendespårare som tar emot förslag från vem som helst.
+* Dokumentationen MÅSTE länka till både den offentliga ärendespåraren och inlämnade kodbasändringar, till exempel i en `README`-fil.
+* Kodbasen MÅSTE ha kommunikationskanaler för användare och utvecklare, till exempel e-postlistor.
+* Det MÅSTE finnas ett sätt att rapportera säkerhetsproblem för ansvarsfull rapportering via en sluten kanal.
+* Dokumentationen MÅSTE innehålla instruktioner för hur man rapporterar potentiellt säkerhetskänsliga problem.
+
+## Test
+
+* Bekräfta att det finns en offentlig ärendespårare.
+* Bekräfta att kodbasen innehåller länkar till den offentliga ärendespåraren och inlämnade kodbasändringar.
+* Bekräfta att det är möjligt att delta i en diskussion med andra användare och utvecklare om programvaran med hjälp av kanaler som beskrivs i kodbasen.
+* Bekräfta att det finns en sluten kanal för att rapportera säkerhetsproblem.
+* Bekräfta att det finns instruktioner för att rapportera säkerhetsproblem privat.
+
+## Offentliga beslutsfattare behöver:
+
+* Följa [regelverksfrågor](../glossary.md#regelverk) i kodbasen, så att en relevant extern regelverksexpert kan ställa upp frivilligt.
+
+## Chefer behöver:
+
+* Följa förvaltningsfrågor i kodbasen, så att externa chefer med relevant erfarenhet kan ställa upp frivilligt.
+* Stödja era erfarna beslutsfattare, utvecklare och formgivare i att fortsätta bidra till kodbasen så länge som möjligt.
+
+## Utvecklare och formgivare behöver:
+
+* Precis som för [granskningar](require-review-of-contributions.md), se till att svara på förfrågningar skyndsamt.
+* Hålla era chefer informerade om den tid och de resurser ni behöver för att stödja andra bidragsgivare.
+* Se till att lämpliga kommunikationskanaler för att ställa frågor till underhållsansvariga och intressenter är lätta att hitta, exempelvis i README-filen.
+* Se till att lämpliga kontaktuppgifter finns med i metadata, exempelvis i publiccode.yml-filen.
+
+## Vidare läsning
+
+* [How to inspire exceptional contributions to your open-source project](https://dev.to/joelhans/how-to-inspire-exceptional-contributions-to-your-open-source-project-1ebf) av Joel Hans.
+* [The benefits of coding in the open](https://gds.blog.gov.uk/2017/09/04/the-benefits-of-coding-in-the-open/) av UK Government Digital Service.

--- a/sv/criteria/make-the-codebase-findable.md
+++ b/sv/criteria/make-the-codebase-findable.md
@@ -1,0 +1,71 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2022-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 14
+title: "Kodbasen ska vara lättfunnen"
+redirect_from:
+  - criteria/findability
+---
+
+# Kodbasen ska vara lättfunnen
+
+Ju lättare en [kodbas](../glossary.md#kodbas) är att hitta, desto fler potentiella nya samarbetspartner kommer att finna den.
+Att bara publicera en kodbas och hoppas att den hittas fungerar inte; det kräver aktivt arbete.
+
+En metadatafil ökar upptäckbarheten.
+Välskriven metadata med en unik och bestående identifierare, såsom ett Wikidata-objekt eller en FSF-programvarukatalogpost (och därmed en del av den semantiska webben), gör kodbasen enklare att referera till, citera, särskilja och upptäcka via tredjepartsverktyg.
+
+## Krav
+
+* Kodbasens namn BÖR vara beskrivande och fritt från förkortningar, akronymer, ordlekar eller organisationsvarumärke.
+* Kodbasen BÖR ha en kort beskrivning som hjälper någon förstå vad kodbasen är till för eller vad den gör.
+* Underhållsansvariga BÖR anmäla kodbasen till relevanta programvarukataloger.
+* Kodbasen BÖR ha en webbplats som beskriver problemet kodbasen löser med hjälp av den terminologi som föredras av olika potentiella användare av kodbasen (däribland tekniker, regelverksexperter och chefer).
+* Kodbasen BÖR vara sökbar via en sökmotor med kodbasens namn.
+* Kodbasen BÖR vara sökbar via en sökmotor genom att beskriva problemet den löser på naturligt språk.
+* Kodbasen BÖR ha en unik och bestående identifierare där posten nämner de huvudsakliga bidragsgivarna, [kodförrådets](../glossary.md#kodförråd) plats och webbplatsen.
+* Kodbasen BÖR innehålla en maskinläsbar metadatabeskrivning, till exempel i en [publiccode.yml](https://github.com/publiccodeyml/publiccode.yml)-fil.
+* Ett dedikerat domännamn för kodbasen är VALFRITT.
+* Regelbundna presentationer vid konferenser av gemenskapen är VALFRITT.
+
+## Test
+
+* Kontrollera att kodbasens namn är beskrivande och fritt från ordlekar.
+* Kontrollera att kodbasens namn är fritt från förkortningar och akronymer, eller att förkortningarna eller akronymerna i namnet är mer allmänt kända än de längre formerna.
+* Kontrollera att kodbasens namn är fritt från organisationsvarumärke, såvida inte den organisationen är kodbasgemenskapens egen.
+* Kontrollera att kodbasens kodförråd har en kort beskrivning.
+* Kontrollera om kodbasen är listad i relevanta programvarukataloger.
+* Kontrollera om det finns en webbplats för kodbasen som beskriver problemet kodbasen löser.
+* Kontrollera att kodbasen visas i sökresultaten i mer än en stor sökmotor vid sökning efter kodbasens namn.
+* Kontrollera att kodbasen visas i sökresultaten i mer än en stor sökmotor vid sökning med naturligt språk, till exempel med den korta beskrivningen.
+* Kontrollera poster med unika och bestående identifierare för omnämnande av de huvudsakliga bidragsgivarna.
+* Kontrollera poster med unika och bestående identifierare för kodförrådets plats.
+* Kontrollera poster med unika och bestående identifierare för kodbasens webbplats.
+* Kontrollera om det finns en maskinläsbar metadatabeskrivningsfil.
+
+## Offentliga beslutsfattare behöver:
+
+* Bidra med en beskrivning av det regelverksområde eller problem som kodbasen verkar inom.
+* Testa problembeskrivningen med kollegor utanför ert sammanhang som inte är bekanta med kodbasen.
+* Presentera hur kodbasen genomför [regelverket](../glossary.md#regelverk) vid relevanta konferenser.
+
+## Chefer behöver:
+
+* Söka i varumärkesdatabaser för att undvika förväxling eller intrång innan ni bestämmer namnet.
+* Använda den korta beskrivningen överallt där kodbasen nämns, till exempel som beskrivning för konton i sociala medier.
+* Budgetera för kompetens inom innehållsutformning och sökmotoroptimering i teamet.
+* Se till att de som deltar i projektet presenterar vid relevanta konferenser.
+
+## Utvecklare och formgivare behöver:
+
+* Hantera sökmotoroptimering, till exempel genom att lägga till en [webbplatskarta](https://www.sitemaps.org/protocol.html).
+* Använda den korta beskrivningen överallt där kodbasen nämns, till exempel som kodförrådets beskrivning.
+* Testa er problembeskrivning med kollegor utanför ert sammanhang som inte är bekanta med kodbasen.
+* Föreslå konferenser där kodbasen kan presenteras och presentera den där.
+
+<p style="page-break-after: always;"></p>
+## Vidare läsning
+
+* [Introduction to Wikidata](https://www.wikidata.org/wiki/Wikidata:Introduction) av Wikidata-gemenskapen.
+* [FSF software directory listing](https://directory.fsf.org/wiki/Main_Page) av Free Software Foundation.
+* [FAIR Guiding Principles for scientific data management and stewardship](https://www.go-fair.org/fair-principles/) av GO FAIR International Support and Coordination Office tillhandahåller en bra lista med egenskaper som gör (meta)data mer maskinellt handlingsbara (och därmed mer sökbara). Vissa gäller direkt för kodbaser, medan andra kan inspirera till utforskande av vad motsvarigheten för kodbaser skulle vara.

--- a/sv/criteria/make-the-codebase-reusable-and-portable.md
+++ b/sv/criteria/make-the-codebase-reusable-and-portable.md
@@ -1,0 +1,77 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 3
+title: "Gör kodbasen återanvändbar och portabel"
+redirect_from:
+  - criteria/reusable-and-portable-codebases
+  - criteria/create-reusable-and-portable-code
+---
+# Gör kodbasen återanvändbar och portabel
+
+Att skapa återanvändbar och portabel [kod](../glossary.md#kod) gör det möjligt för beslutsfattare, utvecklare och formgivare att återanvända det som har utvecklats, testa det, förbättra det och bidra tillbaka med förbättringar, vilket leder till bättre kvalitet, billigare förvaltning och högre tillförlitlighet.
+
+Att genomtänkt och medvetet utforma en [kodbas](../glossary.md#kodbas) för återanvändning gör det möjligt att dela kodbasens uppdrag, vision och omfattning mellan flera parter.
+Kodbaser som utvecklas och används av flera parter har större sannolikhet att dra nytta av en självbärande gemenskap.
+
+Att organisera en kodbas så att den består av väldokumenterade moduler förbättrar återanvändbarheten och förvaltbarheten.
+En modul är enklare att återanvända i [ett annat sammanhang](../glossary.md#olika-sammanhang) om dess syfte är tydligt dokumenterat.
+
+Om källkoden inte är beroende av infrastruktur som är specifik för en viss bidragsgivare, leverantör eller driftsättning, kan den testas av vilken annan bidragsgivare som helst.
+
+## Krav
+
+* Kodbasen MÅSTE vara utvecklad för att vara återanvändbar i olika sammanhang.
+* Kodbasen MÅSTE vara oberoende av hemlig, inte offentliggjord, sluten eller inte öppet licensierad programvara eller tjänster för körning och förståelse.
+* Kodbasen BÖR användas av flera parter.
+* Framtidsplanen BÖR påverkas av flera parters behov.
+* Utvecklingen av kodbasen BÖR vara ett samarbete mellan flera parter.
+* Konfiguration BÖR användas för att låta [källkoden](../glossary.md#källkod) anpassas till sammanhangsspecifika behov.
+* Kodbasen BÖR vara lokaliserbar.
+* Källkod och dess dokumentation BÖR INTE innehålla sammanhangsspecifik information.
+* Kodbasens moduler BÖR dokumenteras på ett sätt som möjliggör återanvändning i kodbaser i andra sammanhang.
+* Programvaran BÖR INTE kräva tjänster eller plattformar som bara finns tillgängliga från en enda leverantör.
+
+## Test
+
+* Bekräfta med någon i en motsvarande roll hos en annan organisation om de kan använda kodbasen och vad det skulle innebära.
+* Bekräfta att kodbasen kan köras utan att använda sluten eller icke öppet licensierad programvara eller tjänster.
+* Om kodbasen är i tidig utveckling före en produktionsklar utgåva, kontrollera då om det finns tecken på ambition att få med sig samarbetspartner.
+   * Eller om kodbasen är mycket mogen och stabil med mycket sällsynta rättelser, programfixar eller bidrag:
+     * Kontrollera att kodbasen används av flera parter eller i flera sammanhang.
+     * Kontrollera att det finns dokumenterade och budgeterade åtaganden för samarbete.
+   * I övrigt:
+     * Kontrollera att kodbasen används av flera parter eller i flera sammanhang.
+     * Kontrollera att kodbasens bidragsgivare kommer från flera parter.
+* Kontrollera att kodbasens filer och incheckningshistorik inte innehåller sammanhangsspecifik information.
+* Kontrollera att programvaran kan driftsättas och köras utan tjänster eller plattformar som bara finns tillgängliga från en enda leverantör.
+
+## Offentliga beslutsfattare behöver:
+
+* Dokumentera ert [regelverk](../glossary.md#regelverk) med tillräcklig tydlighet och detaljrikedom för att det ska kunna förstås utanför sitt ursprungliga sammanhang.
+* Se till att er organisation är listad som känd användare av kodbasen.
+* Identifiera andra organisationer som era team kan samarbeta med.
+
+## Chefer behöver:
+
+* Se till att intressenter och verksamhetsansvariga förstår att återanvändbarhet är ett uttryckligt mål för kodbasen, eftersom det förbättrar kodbasens långsiktiga förvaltbarhet och hållbarhet.
+* Se till att era team samarbetar med andra team.
+
+## Utvecklare och formgivare behöver:
+
+Utforma källkod:
+
+* för återanvändning av andra användare och organisationer oavsett plats,
+* för att lösa ett generellt problem i stället för ett specifikt,
+* i logiskt meningsfulla och isolerade moduler,
+* så att någon i en liknande organisation som står inför ett liknande problem skulle kunna använda (delar av) lösningen.
+
+Se till att kodbasens dokumentation beskriver beroenden vid byggtid och körtid.
+Om ert sammanhang kräver driftsättning på slutna plattformar eller användning av slutna komponenter, se till att samarbetspartner kan utveckla, använda, testa och driftsätta utan dem.
+
+Vid varje incheckning verifierar granskare att innehållet inte innehåller sammanhangsspecifik information såsom värdnamn, personuppgifter och organisationsdata, eller åtkomstnycklar och lösenord.
+
+## Vidare läsning
+
+* [Making source code open and reusable](https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable) av UK Government Digital Service.
+* [Localization vs. Internationalization](https://www.w3.org/International/questions/qa-i18n) av World Wide Web Consortium.

--- a/sv/criteria/publish-with-an-open-license.md
+++ b/sv/criteria/publish-with-an-open-license.md
@@ -1,0 +1,55 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 13
+title: "Publicera under öppen licens"
+redirect_from:
+  - criteria/open-licenses
+---
+# Publicera under öppen licens
+
+En öppen och välkänd licens gör det möjligt för vem som helst att se [källkoden](../glossary.md#källkod) för att förstå hur den fungerar, att fritt använda den och att bidra till [kodbasen](../glossary.md#kodbas).
+Det gör det möjligt för ett leverantörsekosystem att växa fram kring kodbasen.
+
+Att tydligt ange licensen för varje fil i en kodbas underlättar korrekt återanvändning och tillskrivning av delar av en kodbas.
+
+## Krav
+
+* All källkod och dokumentation MÅSTE vara licensierad så att den fritt kan återanvändas, ändras och vidaredistribueras.
+* Programvarans källkod MÅSTE vara licensierad under en [licens godkänd av OSI eller FSF som fri](https://spdx.org/licenses/).
+* All källkod MÅSTE publiceras med en licensfil.
+* Bidragsgivare FÅR INTE krävas att överföra upphovsrätten för sina bidrag till kodbasen.
+* Alla källkodsfiler i kodbasen BÖR innehålla ett upphovsrättsmeddelande och ett licenshuvud som är maskinläsbara.
+* Att ha flera licenser för olika typer av källkod och dokumentation är VALFRITT.
+
+## Test
+
+* Bekräfta att kodbasen är tydligt licensierad.
+* Bekräfta att licensen för källkoden finns på [listan över licenser godkända av OSI eller FSF som fria](https://spdx.org/licenses/) och att licensen för dokumentation [uppfyller Open Definition](https://opendefinition.org/licenses/).
+* Bekräfta att de licenser som används i kodbasen medföljer som filer.
+* Bekräfta att riktlinjer för bidrag och [kodförråds](../glossary.md#kodförråd)konfiguration inte kräver överföring av upphovsrätt.
+* Kontrollera att det finns maskinläsbar licenskontroll i kodbasens tester för [kontinuerlig integrering](../glossary.md#kontinuerlig-integrering).
+
+## Offentliga beslutsfattare behöver:
+
+* Utveckla [regelverk](../glossary.md#regelverk) som kräver att källkod är [öppen källkod](../glossary.md#öppen-källkod).
+* Utveckla regelverk som motverkar icke-öppen källkod och teknik vid upphandling.
+
+## Chefer behöver:
+
+* Arbeta bara med leverantörer av öppen källkod som levererar sin källkod genom att publicera den under en öppen källkodslicens.
+* Vara medvetna om att även om [Creative Commons-licenser](https://creativecommons.org/licenses/) är utmärkta för dokumentation, uppfyller licenser som anger Icke-kommersiell eller Inga bearbetningar INTE kraven på att vara fritt återanvändbara, ändringsbara och vidaredistribuerbara.
+
+## Utvecklare och formgivare behöver:
+
+* Lägga till en ny `license`-fil till varje ny kodbas som skapas.
+* Lägga till ett upphovsrättsmeddelande och ett licenshuvud till varje ny källkodsfil som skapas.
+* Säkerställa att källkod som återanvänds i kodbasen har en licens som är förenlig med kodbasens licens eller licenser.
+
+<p style="page-break-after: always;"></p>
+## Vidare läsning
+
+* [Open source definition](https://opensource.org/osd) av Open Source Initiative; alla licenser för öppen källkod uppfyller definitionen.
+* [Animated video introduction to Creative Commons](https://creativecommons.org/about/videos/creative-commons-kiwi) av Creative Commons Aotearoa New Zealand.
+* [REUSE Initiative specification](https://reuse.software/spec/) av Free Software Foundation Europe för entydig, människoläsbar och maskinläsbar upphovsrätts- och licensinformation.
+* [SPDX License List](https://spdx.org/licenses/) av Linux Foundation med standardiserade, maskinläsbara förkortningar för de flesta licenser.

--- a/sv/criteria/require-review-of-contributions.md
+++ b/sv/criteria/require-review-of-contributions.md
@@ -1,0 +1,65 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 7
+title: "Kräv granskning av bidrag"
+redirect_from:
+  - criteria/require-review
+---
+# Kräv granskning av bidrag
+
+Kollegial granskning av bidrag är avgörande för [källkodens](../glossary.md#källkod) kvalitet och för att minska säkerhets- och driftsrisker.
+
+Att kräva noggrann granskning av bidrag uppmuntrar en kultur där man ser till att varje bidrag håller hög kvalitet, är fullständigt och skapar värde.
+Granskning av källkod ökar chansen att upptäcka och åtgärda potentiella programfel eller misstag innan de läggs till i [kodbasen](../glossary.md#kodbas).
+Att all källkod granskas motverkar en kultur av att klandra enskilda och uppmuntrar i stället en kultur som fokuserar på lösningar.
+
+Ett [regelverk](../glossary.md#regelverk) om skyndsam granskning försäkrar bidragsgivare om en garanterad tid för återkoppling eller gemensam förbättring, vilket ökar både leveranstakten och bidragsgivarnas engagemang.
+
+## Krav
+
+* Alla bidrag som accepteras eller checkas in i utgåveversioner av kodbasen MÅSTE granskas av en annan bidragsgivare.
+* Granskningar MÅSTE omfatta källkod, regelverk, tester och dokumentation.
+* Granskare MÅSTE ge återkoppling på alla beslut att inte acceptera ett bidrag.
+* Granskningsprocessen BÖR bekräfta att ett bidrag överensstämmer med de standarder, den arkitektur och de beslut som fastställts i kodbasen för att klara granskningen.
+* Granskningar BÖR omfatta körning av både programvaran och testerna i kodbasen.
+* Bidrag BÖR granskas av någon i ett annat sammanhang än bidragsgivaren.
+* Versionshanteringssystem BÖR INTE acceptera ogranskade bidrag i utgåveversioner.
+* Granskningar BÖR ske inom två arbetsdagar.
+* Att utföra granskningar med flera granskare är VALFRITT.
+
+## Test
+
+* Bekräfta att varje incheckning i historiken har granskats av en annan bidragsgivare.
+* Bekräfta att granskningar omfattar källkod, regelverk, tester och dokumentation.
+* Bekräfta att avvisade bidrag har förklarats på lämpligt sätt.
+* Kontrollera om riktlinjer för granskare innehåller instruktioner att granska för överensstämmelse med standarder, arkitektur och kodbasens riktlinjer.
+* Kontrollera med granskare om de kör programvaran och testerna under granskningen.
+* Kontrollera med granskare om incheckningar har granskats av en annan bidragsgivare i ett annat sammanhang.
+* Kontrollera om grenskydd används i [versionshanteringssystemet](../glossary.md#versionshantering).
+* Kontrollera att det inte finns ett mönster av perioder mellan bidragsinlämning och granskning där bidragsgivaren behöver vänta längre än två arbetsdagar på meningsfull återkoppling.
+
+## Offentliga beslutsfattare behöver:
+
+* Införa en princip om "fyra ögon" där allt, inte bara källkod, granskas.
+* Använda ett versionshanteringssystem eller en metod som möjliggör granskning och återkoppling.
+
+## Chefer behöver:
+
+* Göra det till ett gemensamt mål att leverera utmärkt programvara.
+* Se till att det att skriva och granska bidrag till källkod, regelverk, dokumentation och tester värderas lika.
+* Skapa en kultur där alla bidrag välkomnas och alla har befogenhet att granska dem.
+* Se till att ingen bidragsgivare någonsin är ensam om att bidra till en kodbas.
+* Skapa ett mandat för utvecklare att prioritera skyndsam granskning av bidrag.
+
+## Utvecklare och formgivare behöver:
+
+* Be andra bidragsgivare till kodbasen att granska ert arbete, i er organisation eller utanför den.
+* Försöka svara på andras granskningsförfrågningar skyndsamt, och ge inledningsvis återkoppling om ändringens grundidé.
+
+## Vidare läsning
+
+* [How to review code the GDS way](https://gds-way.digital.cabinet-office.gov.uk/manuals/code-review-guidelines.html#content) av UK Government Digital Service.
+* Grenskydd på [GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) och [GitLab](https://about.gitlab.com/blog/2014/11/26/keeping-your-code-protected/).
+* [The Gentle Art of Patch Review](https://sage.thesharps.us/2014/09/01/the-gentle-art-of-patch-review/) av Sage Sharp.
+* [Measuring Engagement](https://docs.google.com/presentation/d/1hsJLv1ieSqtXBzd5YZusY-mB8e1VJzaeOmh8Q4VeMio/edit#slide=id.g43d857af8_0177) av Mozilla.

--- a/sv/criteria/use-a-coherent-style.md
+++ b/sv/criteria/use-a-coherent-style.md
@@ -1,0 +1,48 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 15
+title: "Använd en enhetlig stil"
+redirect_from:
+  - criteria/style
+---
+# Använd en enhetlig stil
+
+Att följa en konsekvent och enhetlig stil gör det möjligt för bidragsgivare i olika miljöer att arbeta tillsammans.
+Att ena terminologin minskar friktionen i kommunikationen mellan bidragsgivare.
+
+## Krav
+
+* [Kodbasen](../glossary.md#kodbas) MÅSTE använda en stil- eller skrivguide för kod, antingen kodbasgemenskapens egen eller en befintlig som hänvisas till i kodbasen.
+* Bidrag BÖR klara automatiserade stiltest.
+* Stilguiden BÖR innehålla förväntningar på kommentarer i koden och dokumentation för icke-triviala avsnitt.
+* Att ta med förväntningar på [begriplig engelska](use-plain-english.md) i stilguiden är VALFRITT.
+
+## Test
+
+* Bekräfta att bidrag följer de stilguider som anges i dokumentationen.
+* Kontrollera om det finns automatiserade stiltest.
+
+## Offentliga beslutsfattare behöver:
+
+* Skapa, följa och fortlöpande förbättra en stilguide för [regelverk](../glossary.md#regelverk) och dokumentation och dokumentera det i kodbasen, till exempel i `CONTRIBUTING`- eller `README`-filen.
+
+## Chefer behöver:
+
+* Ta med standarder för skriftspråk, källkod, tester och regelverk i er organisations definition av kvalitet.
+
+## Utvecklare och formgivare behöver:
+
+Om kodbasen inte redan har tekniska riktlinjer eller annan vägledning för bidragsgivare, börja med att lägga till dokumentation i [kodförrådet](../glossary.md#kodförråd) som beskriver hur det görs nu, till exempel i `CONTRIBUTING`- eller `README`-filen.
+Ett viktigt syfte med filen är att kommunicera designval, namngivningskonventioner och andra aspekter som maskiner inte enkelt kan kontrollera.
+Vägledningen bör innefatta vad som förväntas av [källkods](../glossary.md#källkod)bidrag för att de ska sammanslås av förvaltarna, inbegripet källkod, tester och dokumentation.
+Förbättra och utöka dokumentationen fortlöpande med målet att den ska utvecklas till tekniska riktlinjer.
+
+Dessutom:
+
+* Använda en linter.
+* Lägga till konfigurationer för lintern i kodbasen.
+
+## Vidare läsning
+
+* [Programming style](https://en.wikipedia.org/wiki/Programming_style) på Wikipedia.

--- a/sv/criteria/use-continuous-integration.md
+++ b/sv/criteria/use-continuous-integration.md
@@ -1,0 +1,71 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 12
+title: "Använd kontinuerlig integrering"
+redirect_from:
+  - criteria/continuous-integration
+---
+# Använd kontinuerlig integrering
+
+Asynkront samarbete blir möjligt när utvecklare ofta sammanfogar sitt arbete i en delad gren och verifierar det med automatiserade tester.
+Ju oftare sammanslagning sker och ju mindre bidraget är, desto enklare är det att lösa sammanslagningskonflikter.
+
+Automatiserad testning av all funktionalitet ger förtroende för att bidrag fungerar som avsett och inte har infört fel, och gör det möjligt för granskare att fokusera på bidragets struktur och tillvägagångssätt.
+Ju mer fokuserat testet är, desto enklare är det att tydligt identifiera och förstå fel när de uppstår.
+
+Att dokumentera kodbasens arbetsflöde för [kontinuerlig integrering](../glossary.md#kontinuerlig-integrering) hjälper bidragsgivare att förstå vad som förväntas av bidrag.
+Kontinuerlig integrering möjliggör enklare övervakning av [kodbasens](../glossary.md#kodbas) tillstånd.
+
+## Krav
+
+* All funktionalitet i [källkoden](../glossary.md#källkod) MÅSTE ha automatiserade tester.
+* Bidrag MÅSTE klara alla automatiserade tester innan de tas in i kodbasen.
+* Kodbasen MÅSTE ha riktlinjer som förklarar hur bidrag ska struktureras.
+* Kodbasen MÅSTE ha aktiva bidragsgivare som kan granska bidrag.
+* Automatiserade testresultat för bidrag BÖR vara offentliga.
+* Kodbasens riktlinjer BÖR ange att varje bidrag bör fokusera på ett enskilt ärende.
+* Källkodens test- och dokumentationstäckning BÖR övervakas.
+* Att testa [regelverk](../glossary.md#regelverk) och dokumentation för överensstämmelse med källkoden och vice versa är VALFRITT.
+* Att testa regelverk och dokumentation för stil och trasiga länkar är VALFRITT.
+* Att testa programvaran genom att använda exempel i dokumentationen är VALFRITT.
+
+## Test
+
+* Bekräfta att det finns tester.
+* Bekräfta att verktyg för källkodstäckning kontrollerar att täckningen är 100 % av källkoden.
+* Bekräfta att bidrag bara tas in i kodbasen efter att alla tester godkänts.
+* Bekräfta att riktlinjer för bidrag förklarar hur bidrag ska struktureras.
+* Bekräfta att det finns bidrag från de senaste tre månaderna.
+* Kontrollera att testresultaten kan granskas.
+* Kontrollera om data om källkodstäckning publiceras.
+
+## Offentliga beslutsfattare behöver:
+
+* Engagera chefer samt utvecklare och formgivare tidigt i processen och hålla dem engagerade genom hela utvecklingen av ert regelverk.
+* Se till att det också finns automatiserade tester uppsatta för regelverksdokumentation.
+* Åtgärda regelverksdokumentation skyndsamt om den underkänns i ett test.
+* Se till att källkoden speglar alla ändringar i regelverket (se [Upprätthåll versionshantering](maintain-version-control.md)).
+
+## Chefer behöver:
+
+* Se till att testa med verkliga slutanvändare så snabbt och ofta som möjligt.
+* Planera arbetet så att små delar integreras mycket ofta i stället för stora delar mer sällan.
+* Upphandla konsulttjänster som levererar stegvis i linje med planen.
+* Efter ett allvarligt fel, uppmuntra till att publicera incidentrapporter och föra offentlig diskussion om vad som lärdes.
+
+## Utvecklare och formgivare behöver:
+
+* Hjälpa chefer att strukturera arbetsplanen så att den kan integreras som små steg.
+* Hjälpa bidragsgivare att begränsa omfattningen av sina bidrag och funktionsönskemål till att vara så små som är rimligt.
+* Hjälpa chefer och beslutsfattare att testa sina bidrag, till exempel genom att testa deras bidrag för trasiga länkar eller stil.
+* Om viss källkod hanterar förhållanden som är svåra att skapa i en testmiljö, strukturera den så att förhållandena kan simuleras under testning. Resursutmattning som att lagringsutrymmet tar slut och misslyckad minnesallokering är typiska exempel på svårskapade förhållanden.
+* Justera verktyg för testtäckning av kod för att undvika falsklarm till följd av inlining eller andra optimeringar.
+* Driftsätta ofta.
+* Integrera ert arbete minst en gång om dagen.
+
+## Vidare läsning
+
+* [What is continuous integration](https://www.martinfowler.com/articles/continuousIntegration.html) av Martin Fowler.
+* [Use continuous delivery](https://gds-way.cloudapps.digital/standards/continuous-delivery.html) av UK Government Digital Service.
+* [Quality assurance: testing your service regularly](https://www.gov.uk/service-manual/technology/quality-assurance-testing-your-service-regularly) av UK Government Digital Service.

--- a/sv/criteria/use-open-standards.md
+++ b/sv/criteria/use-open-standards.md
@@ -1,0 +1,47 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 11
+title: "Använd öppna standarder"
+redirect_from:
+  - criteria/open-standards
+---
+# Använd öppna standarder
+
+[Öppna standarder](../glossary.md#öppen-standard) garanterar tillgång till den kunskap som krävs för att använda och bidra till [kodbasen](../glossary.md#kodbas).
+De möjliggör samverkan mellan system och minskar risken för leverantörsinlåsning.
+Öppna standarder som är entydiga möjliggör oberoende utveckling av vardera sidan av datautbyte.
+
+## Krav
+
+* För funktioner i kodbasen som underlättar datautbyte MÅSTE kodbasen använda en öppen standard som uppfyller [Open Source Initiatives krav för öppna standarder](https://opensource.org/osr).
+* Alla icke-öppna standarder som används MÅSTE tydligt noteras som sådana i dokumentationen.
+* Alla standarder som valts för användning i kodbasen MÅSTE listas i dokumentationen med en länk till var de finns tillgängliga.
+* Alla icke-öppna standarder som valts för användning i kodbasen FÅR INTE hindra samarbete och återanvändning.
+* Om ingen befintlig öppen standard finns tillgänglig BÖR ansträngning läggas på att utveckla en.
+* Öppna standarder som är maskinellt testbara BÖR föredras framför öppna standarder som inte är det.
+* Icke-öppna standarder som är maskinellt testbara BÖR föredras framför icke-öppna standarder som inte är det.
+
+## Test
+
+* Bekräfta att datautbyte följer en öppen standard godkänd av OSI.
+* Bekräfta att alla icke-öppna standarder som används tydligt dokumenterats som sådana.
+* Bekräfta att dokumentationen innehåller en lista över de standarder som följs i kodbasen, var och en med en fungerande länk, eller ett uttalande om att inga standarder valts.
+
+## Offentliga beslutsfattare behöver:
+
+* Föreskriva användning av öppna standarder överallt där det är möjligt.
+* Förbjuda upphandling av teknik som inte använder öppna standarder.
+
+## Chefer behöver:
+
+* Överväga att bedöma efterlevnaden av öppna standarder i [källkods](../glossary.md#källkod)granskningar.
+
+## Utvecklare och formgivare behöver:
+
+* Lägga till tester för [kontinuerlig integrering](../glossary.md#kontinuerlig-integrering) som kontrollerar efterlevnad av standarderna.
+* Granska incheckningar och andra [kodförråds](../glossary.md#kodförråd)resurser för hänvisningar till standarder och kontrollera dem mot listan över använda standarder.
+
+## Vidare läsning
+
+* [Open Standards principles](https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles), [regelverk](../glossary.md#regelverk)sdokument från UK Cabinet Office.

--- a/sv/criteria/use-plain-english.md
+++ b/sv/criteria/use-plain-english.md
@@ -1,0 +1,63 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 10
+title: "Använd enkel engelska"
+redirect_from:
+  - criteria/understandable-english-first
+---
+# Använd enkel engelska
+
+Engelska är <i>de facto</i>-språket för samarbete inom programvaruutveckling.
+Vissa sammanhang kräver dock andra språk än engelska.
+Därför kan en kodbas ha en uppsättning auktoritativa språk, däribland engelska.
+
+Information från offentlig sektor behöver vara tillgänglig för alla den berör.
+Enkelt och tydligt språk gör [koden](../glossary.md#kod) och vad den gör lättare att förstå för en bredare mångfald av människor.
+
+Översättningar utökar [kodbasens](../glossary.md#kodbas) potentiella räckvidd ytterligare.
+Språk som är lätt att förstå sänker kostnaden för att skapa och underhålla översättningar.
+
+## Krav
+
+* Uppsättningen auktoritativa språk för kodbasens dokumentation MÅSTE vara dokumenterad.
+* Engelska MÅSTE vara ett av de auktoritativa språken.
+* All kodbasdokumentation MÅSTE vara aktuell på alla auktoritativa språk.
+* All [källkod](../glossary.md#källkod) MÅSTE vara på engelska, förutom där [regelverk](../glossary.md#regelverk) tolkas som kod av maskiner.
+* Alla medföljande regelverk MÅSTE finnas tillgängliga, eller ha en sammanfattning, på alla auktoritativa språk.
+* Det BÖR INTE finnas några förkortningar, akronymer, ordlekar eller juridiska/språkliga/domänspecifika termer i kodbasen utan en föregående förklaring eller en länk till en förklaring.
+* Dokumentation BÖR sikta mot en läsnivå motsvarande högstadiet, i enlighet med rekommendationerna i [riktlinjerna för tillgänglighet av webbinnehåll 2](https://www.w3.org/WAI/WCAG22/quickref/?showtechniques=315#reading-level).
+* Att tillhandahålla ytterligare artighetsöversättningar av kod, dokumentation eller tester är VALFRITT.
+
+## Test
+
+* Bekräfta att kodbasen dokumenterar vilka språk som är auktoritativa.
+* Bekräfta att kodbasens dokumentation finns tillgänglig på engelska.
+* Bekräfta att översättningar på auktoritativa språk har samma innehåll.
+* Bekräfta att källkoden är på engelska, eller bekräfta att all icke-engelsk källkod är regelverk eller termer med föregående förklaringar.
+* Bekräfta att alla regelverk är fullständigt översatta eller har en sammanfattning på alla auktoritativa språk.
+* Kontrollera att det inte finns oförklarade förkortningar, akronymer, ordlekar eller juridiska/språkliga/domänspecifika termer i dokumentationen.
+* Kontrollera stavning, grammatik och läsbarhet i dokumentationen.
+
+## Offentliga beslutsfattare behöver:
+
+* Testa regelbundet med andra chefer, utvecklare och formgivare i processen om de förstår vad ni levererar och hur ni dokumenterar det.
+
+## Chefer behöver:
+
+* Fastställa vilka språk som är auktoritativa för kodbasens dokumentation, med hänvisning till relevant regelverk om tillämpligt.
+* Säkerställa att det finns bemanning eller budget för att tillhandahålla översättning till auktoritativa språk.
+* Försöka begränsa användningen av förkortningar, akronymer, ordlekar eller juridiska/språkliga/domänspecifika termer i intern kommunikation inom och mellan team och intressenter. Lägga till sådana termer i en ordlista och länka till den från de ställen de används.
+* Vara kritiska mot dokumentation och beskrivningar i förslag och ändringar. Om ni inte förstår något kommer andra förmodligen också ha svårt med det.
+
+## Utvecklare och formgivare behöver:
+
+* Testa regelbundet med beslutsfattare och chefer om de förstår vad ni levererar och hur ni dokumenterar det.
+* Fråga någon utanför ert sammanhang om de förstår innehållet (till exempel en utvecklare som arbetar med en annan kodbas).
+* Om det finns både obligatoriska auktoritativa översättningar och artighetsöversättningar efter bästa förmåga, se till att det tydligt framgår vilken kategori varje översättning tillhör.
+
+## Vidare läsning
+
+* Att uppfylla [riktlinjerna för tillgänglighet av webbinnehåll 2.2, riktlinje 3.1.5 Läsnivå](https://www.w3.org/WAI/WCAG22/quickref/?showtechniques=315#reading-level) av W3C gör textinnehåll läsbart och begripligt.
+* [EU:s tillgänglighetsdirektiv](https://ec.europa.eu/digital-single-market/en/web-accessibility) av Europeiska kommissionen är ett exempel på reglering som kräver hög tillgänglighet.
+* [Definition of plain language](https://www.plainlanguage.gov/about/definitions/) av United States General Services Administration.

--- a/sv/criteria/welcome-contributors.md
+++ b/sv/criteria/welcome-contributors.md
@@ -1,0 +1,63 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+order: 4
+title: "Välkomna bidragsgivare"
+redirect_from:
+  - criteria/open-to-contributions
+---
+# Välkomna bidragsgivare
+
+Atmosfären i [kodbasens](../glossary.md#kodbas) gemenskap hjälper användare att välja en kodbas framför en annan.
+Att välkomna vem som helst som bidragsgivare gör det möjligt för gemenskapen att växa och bestå över tid.
+En gemenskap där bidragsgivare har tydliga vägar att påverka kodbasens och gemenskapens mål och framsteg löper mindre risk att splittras och gå skilda vägar.
+Nya deltagare behöver förstå och lita på kodbasgemenskapens styrning.
+
+## Krav
+
+* Kodbasen MÅSTE tillåta vem som helst att lämna förslag på ändringar av kodbasen.
+* Kodbasen MÅSTE innehålla riktlinjer för bidrag som förklarar vilka typer av bidrag som välkomnas och hur bidragsgivare kan engagera sig, till exempel i en `CONTRIBUTING`-fil.
+* Kodbasen MÅSTE dokumentera styrningen av kodbasen, bidragen och dess gemenskap, till exempel i en `GOVERNANCE`-fil.
+* Riktlinjerna för bidrag BÖR dokumentera vem som förväntas stå för kostnaderna för granskning av bidrag.
+* Kodbasen BÖR synliggöra de medverkande organisationernas uttalade engagemang i utvecklingen och förvaltningen.
+* Kodbasen BÖR ha en offentligt tillgänglig framtidsplan.
+* Kodbasen BÖR publicera statistik över kodbasens aktivitet.
+* Att ha med en uppförandekod för bidragsgivare i kodbasen är VALFRITT.
+
+## Test
+
+* Bekräfta att det är möjligt att lämna förslag på ändringar av kodbasen.
+* Bekräfta att det finns riktlinjer för bidrag.
+* Bekräfta att kodbasens styrning är tydligt beskriven, inbegripet hur man kan påverka styrningen.
+* Kontrollera att riktlinjerna för bidrag anger vem som förväntas stå för kostnaderna för granskning av bidrag.
+* Kontrollera om det finns en lista över medverkande organisationer.
+* Kontrollera om det finns en framtidsplan.
+* Kontrollera om det finns publicerad aktivitetsstatistik.
+* Kontrollera om det finns en uppförandekod.
+
+## Offentliga beslutsfattare behöver:
+
+* Lägga till en lista i kodbasen med andra resurser som [regelverk](../glossary.md#regelverk)sexperter, icke-statliga organisationer och akademiker skulle finna användbara för att förstå eller återanvända ert regelverk.
+* Överväga att lägga till kontaktuppgifter så att andra beslutsfattare som överväger samarbete kan be er om råd.
+
+## Chefer behöver:
+
+* Se till att dokumentationen av styrningen omfattar den nuvarande processen för hur man gör ändringar i styrningen.
+* Om gemenskapen har viss samsyn kring hur styrningen bör förändras, formulera idéerna som ambitioner och ta med dem i dokumentationen.
+* Se till att ni vid behov har avsatt budget för granskningsprocessen för bidrag enligt överenskommelse i kodbasgemenskapen.
+* Se till att dokumentationen förklarar hur varje organisation är engagerad i kodbasen, vilka resurser den har tillgängliga och under hur lång tid.
+* Stödja era erfarna beslutsfattare, utvecklare och formgivare i att vara en del av gemenskapen så länge som möjligt.
+
+<p style="page-break-after: always;"></p>
+## Utvecklare och formgivare behöver:
+
+* Svara snabbt på förfrågningar.
+* Hålla era chefer informerade om den tid och de resurser ni behöver för att stödja andra bidragsgivare.
+* Kommunicera tydligt till bidragsgivare vad de behöver göra för att säkerställa att deras bidrag kan integreras.
+
+## Vidare läsning
+
+* [Building welcoming communities](https://opensource.guide/building-community/) av Open Source Guides.
+* [The Open Source Contributor Funnel](https://mikemcquaid.com/2018/08/14/the-open-source-contributor-funnel-why-people-dont-contribute-to-your-open-source-project/) av Mike McQuaid.
+* [Leadership and governance](https://opensource.guide/leadership-and-governance/) för växande gemenskapsprojekt för [fri- och öppen programvara](../glossary.md#öppen-källkod), av Open Source Guides.
+* [Building online communities](http://hintjens.com/blog:117) av Pieter Hintjens (lång läsning!).

--- a/sv/foreword-print.html
+++ b/sv/foreword-print.html
@@ -1,0 +1,42 @@
+---
+---
+
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="assets/github-markdown.css">
+  <link rel="stylesheet" href="assets/print.css">
+  <title>{{ site.title }}</title>
+  <style>
+  /* Print specific */
+
+    @media print {
+      @page :left {
+        @top-left {
+          content: counter(page, lower-roman);
+        }
+      }
+      @page :right {
+        @top-right {
+          content: counter(page, lower-roman);
+        }
+      }
+    }
+
+  </style>
+</head>
+<body class="markdown-body">
+
+  <article id="section-foreword">
+
+    {% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "foreword.md" %}{{page.content | markdownify}}{% endif%}{% endfor %}
+
+  </article>
+
+</body>
+</html>

--- a/sv/foreword.md
+++ b/sv/foreword.md
@@ -1,0 +1,173 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+redirect_from:
+  - introduction
+---
+# Förord
+
+Standarden för offentlig kod är en uppsättning kriterier som stödjer offentliga organisationer i att gemensamt utveckla och förvalta programvara och regelverk.
+
+Alla som utvecklar programvara eller regelverk i offentligt syfte kan använda standarden för att arbeta mot offentliga tjänster av högre kvalitet som är mer kostnadseffektiva, med mindre risk och mer kontroll.
+
+Förordet introducerar begreppet offentlig kod och förklarar varför det är viktigt.
+
+## Definition av offentlig kod
+
+Offentlig kod är både källkod (såsom programvara och algoritmer) och offentligt regelverk som verkställs i ett offentligt sammanhang, av människor eller maskiner.
+Det omfattar den programvara som byggts för att fungera med och som offentlig infrastruktur, tillsammans med arrangemangen för dess framställning.
+Offentlig kod skiljer sig uttryckligen från vanlig programvara eftersom den verkar under fundamentalt annorlunda omständigheter och förväntningar.
+
+## Skäl för offentlig kod
+
+Det finns många anledningar till varför offentlig kod är relevant nu.
+
+### Programkod == juridisk kod
+
+Programvara är offentlig infrastruktur.
+
+Under 2000-talet kan programvara anses vara viktig offentlig infrastruktur.
+Programvaran uttrycker i allt högre grad inte bara befintligt regelverk utan ger även upphov till nya, till exempel när algoritmer avgör vilka stadsdelar som behöver extra sociala insatser eller polisresurser.
+
+Programvarans mekanismer, algoritmer och datainsamling har blivit nyckelelement i genomförandet av offentliga regelverk.
+Programkod verkställer nu regelverk som formulerats genom demokratiska förfaranden.
+Båda formerna av kod sätter villkoren för hur samhället fungerar utifrån demokratiskt fastställda offentliga värden; lagstiftning verkställs av människor, programkod av maskiner.
+Med andra ord har programkod i allt högre grad börjat motsvara juridisk kod.
+
+Programvara bör därför omfattas av principerna för demokratisk styrning.
+
+### Traditionell offentlig upphandling av programvara
+
+Nuvarande metoder för offentlig programvaruproduktion har inte gynnat leveransen av offentliga tjänster.
+
+Under det senaste årtiondet har offentliga organisationer som köpt färdiga programvarulösningar ibland blivit överraskade av att upptäcka att de:
+
+* inte kan ändra sin programvara för att spegla förändrat regelverk eller dra nytta av ny teknik
+* inte har tillgång till sina data eftersom de är inlåsta i slutna system
+* ombeds betala ständigt ökande licensavgifter
+
+### Teknisk suveränitet och demokratiskt ansvarsutkrävande
+
+Offentliga institutioner, tjänstepersoner och invånare förtjänar bättre.
+
+Vi anser att den programvara som driver vårt samhälle inte längre kan vara en svart låda, kontrollerad av utomstående företag som håller den underliggande logiken i sin programvara dold i slutna kodbaser.
+I stället behöver myndigheter och de människor de tjänar teknisk suveränitet.
+Det gör det möjligt för dem att bestämma och styra offentlig programvaras funktion, precis som de kan bestämma och styra regelverk som formulerats i lag.
+Medborgare och det civila samhället behöver insyn i programvaran och möjlighet att utkräva ansvar.
+
+Utformningen av programvara som grundläggande samhällsinfrastruktur bör värna digitala medborgares rättigheter.
+
+### Att utforma verkligt offentlig programvara
+
+Offentlig kod står i centrum för moderna offentliga institutioner, formar tjänstepersoners arbete och påverkar nästan alla invånares liv.
+
+Offentlig programvara måste därför vara:
+
+* möjlig att granska
+* ansvarsutkrävbar
+* begriplig för dem den tjänar
+
+Den måste spegla värderingarna i det samhälle den tjänar, till exempel genom att vara inkluderande och icke-diskriminerande.
+
+De flesta slutna programvarusystem som för närvarande används av offentliga organisationer uppfyller inte kraven.
+Offentlig kod gör det.
+
+### Offentlig kods värden
+
+Vi anser att offentlig kod har följande kärnvärden:
+
+* Inkluderande
+* Användbar
+* Öppen
+* Läsbar
+* Ansvarsutkrävbar
+* Tillgänglig
+* Hållbar
+
+## Hur offentlig kod fungerar
+
+Offentlig kod är fri- och öppen programvara avsedd att fylla offentliga organisationers väsentliga roll.
+Genom användning bidrar andra förvaltningar tillbaka till programvaran, så att dess utveckling och förvaltning blir genuint gemensam.
+
+Att vara öppen möjliggör mycket annat.
+
+Lokalt ansvar och demokratiskt ansvarsutkrävande säkerställs när en offentlig organisation genomför och förvaltar sin egen offentliga kod.
+Tack vare öppenheten och en bredare bidragsgivarbas blir programvaran säkrare eftersom den drar nytta av att många ögon upptäcker potentiella brister.
+Många bidragsgivare delar förvaltningsarbetet för att hålla den funktionell och modern, vilket förbättrar den långsiktiga förvaltbarheten.
+Den delade arbetsbelastningen är mer hållbar nu och i framtiden.
+Öppenheten gör både koden och dess data lättare att anpassa i framtiden.
+Koden blir enklare att omforma, återanvända för nytt ändamål eller avveckla.
+Allt detta leder till offentlig infrastruktur med lägre risk.
+
+Genom att samla resurser kan offentliga förvaltningar ägna extra uppmärksamhet åt hur programvaran anpassas så att den fungerar bäst i varje lokalt sammanhang, vilket skapar bättre användarupplevelser för slutanvändarna (invånare eller medborgare).
+
+### Offentlig kods ekonomi
+
+Offentlig kod erbjuder en bättre ekonomisk modell för offentliga organisationer såväl som för kommersiella företag.
+Det är ett alternativ till traditionell programvaruupphandling som ökar lokal kontroll och ekonomiska möjligheter.
+
+Utformad från början för att vara öppen, anpassningsbar och med dataportabilitet kan den utvecklas av egen personal eller betrodda leverantörer.
+Eftersom koden är öppen kan den offentliga förvaltningen byta leverantör vid behov.
+Öppen kod ökar möjligheterna för offentligt lärande och granskning, vilket gör det möjligt för den offentliga förvaltningen att upphandla mindre avtal.
+Mindre upphandlingar är enklare för lokala små och medelstora företag att lämna anbud på.
+Offentliga förvaltningar kan använda sina egna programvaruinköp för att stimulera innovation och konkurrens i sin lokala ekonomi.
+
+Det kan ses som en investering som leder till framtida ekonomisk tillväxt.
+Fler leverantörer kommer att behövas på grund av ökande teknikefterfrågan.
+
+### Att upphandla offentlig kod
+
+Offentlig kod kan användas och utvecklas av permanenta interna utvecklingsteam, konsulter eller externa leverantörer.
+Leverantörer till offentliga organisationer kan ta med offentlig kod i sina anbud.
+
+För att använda befintlig offentlig kod behöver du i din budget och projektplanering ange att din nya lösning ska använda den kodbasen.
+För att uppmuntra nytänkande anpassning av den offentliga koden till ditt sammanhang kan du beskriva tjänsten eller resultatet i ditt avtal.
+
+## Målen för standarden för offentlig kod
+
+Standarden stödjer utvecklare, formgivare, chefer och offentliga beslutsfattare att:
+
+* utveckla högkvalitativ programvara och regelverk för bättre leverans av offentliga tjänster
+* utveckla kodbaser som kan återanvändas mellan sammanhang och gemensamt förvaltas
+* minska teknisk skuld och andelen misslyckade projekt
+* ha mer detaljerad kontroll över, och förmåga att fatta beslut om, sina IT-system
+* förbättra leverantörsrelationer med en bättre ekonomisk modell
+
+Potentiella användare av kodbaser som testats mot standarden för offentlig kod kan förvänta sig att de är mycket återanvändbara, lätta att förvalta och av hög kvalitet.
+
+Standarden för offentlig kod gör detta genom att:
+
+* fastställa en gemensam terminologi för utveckling av offentlig kod
+* upprätta mått som hjälper till att utveckla offentlig kod av hög kvalitet
+* tillhandahålla vägledning om hur man uppfyller dess kriterier och tillämpar efterlevnad i praktiken
+
+Standarden för offentlig kod är avsedd att vara oberoende av tid och teknik.
+
+### Vem standarden är till för
+
+Standarden för offentlig kod är till för de människor som skapar och återanvänder offentlig kod:
+
+* offentliga beslutsfattare
+* verksamhets- och projektchefer
+* utvecklare och formgivare
+
+De arbetar på:
+
+* institutioner, organisationer och förvaltningar inom offentlig sektor
+* konsultföretag och leverantörer av informationsteknik och regelverkstjänster till offentliga organisationer
+
+Den riktar sig inte till offentliga organisationers slutanvändare (invånare eller medborgare), journalister eller akademiker.
+
+## Vidare läsning
+
+* ["Modernising Public Infrastructure with Free Software" (vitbok)](https://download.fsfe.org/campaigns/pmpc/PMPC-Modernising-with-Free-Software.pdf) av Free Software Foundation Europe.
+
+### Filmer om offentlig kod
+
+* [Collaborative Code is the Future of Cities @ DecidimFest 2019](https://www.youtube.com/watch?v=cnJtnZ9Cx1o). Föredrag av Ben Cerveny om bakgrunden till Foundation for Public Code.
+* [Public Money? Public Code! - Panel @ Nextcloud Conference 2019](https://youtube.com/watch?v=QHFkD4xfd6c). Berör ämnen som upphandling, lagstiftning med mera.
+
+## Engagera dig
+
+Standarden är ett levande dokument.
+[Läs vår bidragsguide](/CONTRIBUTING.md) för att lära dig hur du kan göra den bättre.

--- a/sv/glossary.md
+++ b/sv/glossary.md
@@ -1,0 +1,86 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+---
+# Ordlista
+
+## Kod
+
+Varje uttryckligen beskrivet system av regler.
+Det omfattar lagar, regelverk och förordningar, liksom källkod som används för att bygga programvara.
+Båda är regler där vissa utförs av människor och andra av maskiner.
+
+## Kodbas
+
+Varje avgränsat paket av kod (både källkod och regelverk), de tester och den dokumentation som krävs för att tillämpa ett regelverk eller köra programvara.
+
+Det kan till exempel vara ett dokument eller ett kodförråd med versionshantering.
+
+## Kontinuerlig integrering
+
+Inom programvaruutveckling är kontinuerlig integrering (CI) arbetssättet att så ofta som rimligt sammanfoga alla utvecklares arbetskopior till en utvecklingsgren i en kodbas.
+
+## Olika sammanhang
+
+Två sammanhang är olika om de tillhör olika offentliga organisationer eller olika avdelningar för vilka det inte finns en gemensam beslutsfattare som naturligt kan verka för att samarbete sker.
+
+## Allmänheten
+
+Allmänheten i stort: slutanvändare av koden och de tjänster som bygger på den.
+
+Till exempel betraktas en kommuns invånare som slutanvändare av kommunens tjänster och av all kod som driver tjänsterna.
+
+## Öppen källkod
+
+Öppen källkod definieras av Open Source Initiative i deras [definition av öppen källkod](https://opensource.org/osd-annotated).
+
+## Öppen standard
+
+En öppen standard är varje standard som uppfyller Open Source Initiatives [krav för öppna standarder](https://opensource.org/osr).
+
+## Regelverk
+
+Ett regelverk är ett avsiktligt system av principer för att vägleda beslut och uppnå ändamålsenliga resultat.
+Ett regelverk är en avsiktsförklaring som genomförs som en procedur eller ett protokoll.
+Regelverk antas vanligtvis av ett styrande organ inom en organisation.
+Regelverk kan bistå vid såväl subjektivt som objektivt beslutsfattande.
+
+Offentliga regelverk är den process genom vilken myndigheter omsätter sin politiska vision till program och åtgärder för att uppnå önskade resultat.
+
+På nationell nivå är regelverk och lagstiftning vanligtvis åtskilda.
+Skillnaden är ofta mer otydlig på kommunal nivå.
+
+I standarden avser ordet "regelverk" regelverk som skapats och antagits av offentliga organisationer såsom myndigheter och kommuner.
+
+## Offentlig kod
+
+Offentlig kod är fri- och öppen programvara som utvecklats av offentliga organisationer, tillsammans med det regelverk och den vägledning som behövs för samarbete och återanvändning.
+
+Offentlig kod är både källkod (såsom programvara och algoritmer) och offentligt regelverk som verkställs i ett offentligt sammanhang, av människor eller maskiner.
+
+Offentlig kod tjänar allmänintresset, är öppen, läsbar, ansvarsutkrävbar, tillgänglig och hållbar.
+
+Genom att utveckla offentlig kod oberoende av det lokala sammanhang den utvecklades för, men ändå möjlig att införa där, samt genom att dokumentera utvecklingsprocessen öppet, kan offentlig kod utgöra en byggsten för andra att:
+
+* återanvända i sitt lokala sammanhang
+* använda som utgångspunkt för fortsatt utveckling
+* använda som grund för lärande
+
+För att underlätta återanvändning överlåts offentlig kod antingen till allmän egendom eller licensieras med en öppen licens som tillåter andra att fritt se och återanvända verket samt skapa härledda verk.
+
+## Kodförråd
+
+Ett kodförråd är en lagringsplats som används av versionshanteringsverktyg för filer och metadata i en kodbas.
+Kodförråd gör det möjligt för flera bidragsgivare att arbeta med samma uppsättning filer.
+Kodförråd kan lagra flera versioner av filuppsättningar.
+
+## Källkod
+
+Människoläsbar text i ett datorprogram som kan översättas till maskininstruktioner.
+
+## Versionshantering
+
+Versionshantering innebär att spåra ändringar i källkod och tillhörande filer över tid.
+Förändringar identifieras vanligtvis med en kod, kallad *revisionsnummer* (eller liknande).
+Varje revision kopplas till tidpunkten den gjordes och den person som genomförde ändringen, vilket gör det enklare att spåra kodens utveckling.
+Versionshanteringssystem kan användas för att jämföra olika versioner med varandra och för att se hur innehållet har förändrats över tid.

--- a/sv/index.md
+++ b/sv/index.md
@@ -1,0 +1,46 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+toc: false
+---
+# Vägledning för samarbete kring fri- och öppen programvara i offentlig sektor
+
+Standarden för offentlig kod är en uppsättning kriterier som stödjer offentliga organisationer i att gemensamt utveckla och förvalta programvara och regelverk.
+
+Standarden för offentlig kod ger vägledning till offentliga organisationer som vill samarbeta framgångsrikt kring lösningar med fri- och öppen programvara tillsammans med liknande organisationer på andra platser.
+Den innehåller råd för beslutsfattare, chefer inom offentlig förvaltning, utvecklare och leverantörer.
+Standarden för offentlig kod främjar gemensamt skapande av kodbaser som är användbara, öppna, läsbara, ansvarsutkrävbara, tillgängliga och hållbara.
+Den är avsedd att vara tillämpbar på kodbaser för alla förvaltningsnivåer, från överstatlig till kommunal.
+
+Standarden för offentlig kod definierar "[offentlig kod](glossary.md#offentlig-kod)" som fri- och öppen programvara utvecklad av offentliga organisationer, tillsammans med det regelverk och den vägledning som behövs för samarbete och återanvändning.
+
+Kriterierna i standarden för offentlig kod är i linje med riktlinjer och bästa praxis för utveckling av fri- och öppen programvara.
+
+{% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "foreword.md" %}
+Ytterligare sammanhang och bakgrund finns i [förordet](foreword.md).
+{% endif%}{% endfor %}
+
+## Innehåll
+
+* [Läsanvisning: hur du tolkar standarden](readers-guide.md)
+* [Ordlista](glossary.md)
+* [Kriterier](criteria/){% assign sorted = site.pages | sort:"order" %}{% for page in sorted %}{% if page.dir == "/sv/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
+  * [{{page.title}}]({{page.url | relative_url}}){% endif%}{% endif%}{% endif%}{% endfor %}
+* [Upphovspersoner](AUTHORS.md)
+* [Bidragsguide](CONTRIBUTING.md)
+* [Uppförandekod](CODE_OF_CONDUCT.md)
+* [Styrning](GOVERNANCE.md)
+* [Versionshistorik](RELEASE_NOTES.md)
+* [Licens](license.html)
+
+## Gemenskapssamtal
+
+Delta i våra [gemenskapssamtal](https://community.standardforpubliccode.org/) eller säg hej på vårt [diskussionsforum](https://github.com/standard-for-public-code/standard-for-public-code/discussions).
+
+## Övriga resurser
+
+* Inofficiella [gemenskapsöversättningar av standarden](https://translations.standardforpubliccode.org/) till andra språk
+* [Självutvärdering av efterlevnad av standarden](https://publiccodenet.github.io/assessment-eligibility/) för kodbaser med fri- och öppen programvara inom offentlig sektor
+* [Granskningsmall för standardens kriterier](/docs/review-template.html) som används av förvaltarna på Foundation for Public Code vid kodbasgranskning
+* [Kompakt kravchecklista](https://github.com/standard-for-public-code/standard-for-public-code/releases/download/0.8.1/standard-checklist-0.8.1.pdf) för utskrift och diskussioner
+* [Gemenskapsbyggd handledning](https://standard-for-public-code.github.io/community-implementation-guide-standard/) till standarden för offentlig kod

--- a/sv/print-cover.html
+++ b/sv/print-cover.html
@@ -1,0 +1,262 @@
+---
+---
+
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2021-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
+<html lang="sv">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>{{ site.title }}</title>
+  <style>
+    html {
+      font-family: Mulish;
+      font-size: 16pt;
+      margin: 0;
+      padding: 0;
+    }
+
+    *,
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    article {
+      position: relative;
+    }
+
+    article>section {
+      width: 21.6cm;
+      height: 30.3cm;
+      top: 0;
+      bottom: 0;
+      position: absolute;
+    }
+
+    #back {
+      left: 0;
+    }
+
+    #back>* {
+      position: absolute;
+      left: 2.3cm;
+      width: 16cm;
+    }
+
+    #front {
+      right: 0;
+    }
+
+    #front>* {
+      position: absolute;
+      left: 2cm;
+      width: 16cm;
+    }
+
+    /* Back */
+
+    #back-text {
+      position: absolute;
+      top: 2.3cm;
+    }
+
+    #back-text>p {
+      margin-bottom: 1em;
+    }
+
+    #back img[alt="pekande hand"] {
+      right: 0;
+      top: 18cm;
+      width: 18cm;
+      left: auto;
+    }
+
+    #logo {
+      bottom: 2cm;
+    }
+
+    #logo>img {
+      height: 2cm;
+    }
+
+    ol {
+      column-count: 2;
+      font-size: 12pt;
+      list-style-position: inside;
+    }
+
+    /* Front */
+
+    div#title-block {
+      position: absolute;
+      top: 2.3cm;
+    }
+
+    h1.title {
+      font-size: 3.5em;
+      font-weight: 700;
+    }
+
+    /* Audience blocks */
+
+    ul.audiences {
+      position: absolute;
+      top: 10cm;
+      list-style: none;
+      font-size: 1.25em;
+      padding-left: 0;
+    }
+
+    .audiences li,
+    .audiences lh {
+      display: block;
+      margin-bottom: .5cm;
+    }
+
+    .audiences lh {
+      margin-bottom: 1cm;
+    }
+
+    .audiences li {
+      padding-left: 1.2cm;
+    }
+
+    .audiences li::before {
+      margin-top: -.03cm;
+    }
+
+    [id$="public-policy-makers-what-you-need-to-do"]:before,
+    [id$="managers-what-you-need-to-do"]:before,
+    [id$="developers-and-designers-what-you-need-to-do"]:before {
+      display: block;
+      position: absolute;
+      content: 'A';
+      text-align: center;
+      width: 1cm;
+      height: 1cm;
+      color: white;
+      display: inline-block;
+      margin-left: -1.2cm;
+      box-sizing: border-box;
+      padding: 0.20cm;
+      font-size: .5cm;
+      font-weight: 900;
+    }
+
+    [id$="public-policy-makers-what-you-need-to-do"]:before {
+      background-color: #00EFB5;
+      content: 'B';
+    }
+
+    [id$="managers-what-you-need-to-do"]:before {
+      background-color: #FF6D1C;
+      content: 'C';
+    }
+
+    [id$="developers-and-designers-what-you-need-to-do"]:before {
+      background-color: #8626FF;
+      content: 'U';
+    }
+
+    /* Hands */
+
+    #front img[alt="handslag"] {
+      left: 0;
+      right: 0;
+      top: 18cm;
+      width: 21.6cm;
+    }
+
+    /* Version info */
+
+    #version-info {
+      bottom: 2cm;
+      font-size: .75em;
+    }
+
+    /* Print specific */
+
+    @media print {
+      @page {
+        /* A4 times 2 plus a back of about 6mm and a 3mm bleed on every side */
+        size: 43.2cm 30.3cm;
+        margin: 0;
+        padding: 0;
+        background-color: white;
+      }
+    }
+
+    /* Screen mock-up when using a browser */
+
+    @media screen {
+      body {
+        background-color: whitesmoke;
+      }
+
+      article {
+        display: block;
+        background-color: white;
+        min-height: 30.3cm;
+        max-height: 30.3cm;
+        min-width: 43.2cm;
+        max-width: 43.2cm;
+      }
+    }
+  </style>
+</head>
+
+<body>
+
+  <article>
+    <section id="back">
+      <div id="back-text">
+        <p>
+          Standarden för offentlig kod främjar gemensamt skapande av kodbaser som är användbara, öppna, läsbara, ansvarsutkrävbara, tillgängliga och hållbara.
+          Standarden innehåller vägledning för beslutsfattare, chefer, formgivare och utvecklare som skapar och förvaltar kodbaser.
+        </p>
+        <p>
+          Standarden anger kriterierna:
+          {% assign sorted = site.pages | sort:"order" %}
+          <ol>
+            {% for page in sorted %}{% if page.dir == "/sv/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
+            <li>{{page.title}}</li>{% endif%}
+            {% endif%}  {% endif%}{% endfor %}
+          </ol>
+        </p>
+      </div>
+
+      <img src="assets/hand-point.svg" alt="pekande hand">
+
+    </section>
+
+    <section id="front">
+      <div id="title-block">
+        <p>Begäran om bidrag</p>
+        <h1 class="title">Standarden för offentlig kod</h1>
+      </div>
+
+      <ul class="audiences">
+        <lh>Vad offentlig kod är och hur den kan tillämpas, för:</lh>
+        <li id="first-page-public-policy-makers-what-you-need-to-do">Offentliga beslutsfattare</li>
+        <li id="first-page-managers-what-you-need-to-do">Chefer</li>
+        <li id="first-page-developers-and-designers-what-you-need-to-do">Utvecklare och formgivare</li>
+      </ul>
+
+      <img src="assets/hands-shake.svg" alt="handslag">
+
+      <div id="version-info">
+        <p><strong>Utkast</strong><br/>Version <span class="standard-version">0.8.1</span></p>
+        <p><img src="/assets/cc-zero.svg" alt="Licensierad CC0" height="46"></p>
+        <p>https://www.standardforpubliccode.org</p>
+      </div>
+    </section>
+  </article>
+
+</body>
+
+</html>

--- a/sv/readers-guide.md
+++ b/sv/readers-guide.md
@@ -1,0 +1,72 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
+---
+# Läsanvisning
+
+Standarden beskriver ett antal kriterier.
+Alla kriterier har enhetliga avsnitt som tydliggör hur man skapar utmärkt offentlig kod.
+
+Hänvisningar till "beslutsfattare", "chefer" samt "utvecklare och formgivare" gäller alla som utför uppgifter förknippade med rollerna, oavsett deras tjänstetitel.
+Det är vanligt att enskilda personer har uppgifter som spänner över flera roller.
+
+Nedan följer en kort förklaring av vart och ett av avsnitten och hur de används inom standardens kriterier.
+
+## Inledning
+
+Avsnittet förklarar vad kriteriet syftar till att uppnå och varför det är viktigt för kodbasens användare och bidragsgivare.
+
+## Krav
+
+Avsnittet listar vad som behöver göras för att uppfylla standarden.
+
+Följande nyckelord i dokumentet ska tolkas enligt beskrivningen i [IETF RFC 2119](https://tools.ietf.org/html/rfc2119):
+
+* MÅSTE (MUST)
+* FÅR INTE (MUST NOT)
+* KRÄVS (REQUIRED)
+* SKALL (SHALL)
+* SKALL INTE (SHALL NOT)
+* BÖR (SHOULD)
+* BÖR INTE (SHOULD NOT)
+* REKOMMENDERAS (RECOMMENDED)
+* FÅR (MAY)
+* VALFRITT (OPTIONAL)
+
+## Test
+
+Avsnittet erbjuder åtgärder du kan vidta för att se om ett bidrag uppfyller standarden.
+Det är avgörande om du vill tillämpa standarden i praktiken.
+
+Vi har försökt formulera det så att även någon som inte är djupt insatt i ämnet kan göra en grundläggande kontroll av efterlevnaden.
+
+## Offentliga beslutsfattare behöver:
+
+Avsnittet riktar sig särskilt till beslutsfattare genom att erbjuda dem konkreta åtgärder de kan vidta i sin roll.
+
+Offentliga beslutsfattare sätter prioriteringar och mål för projekt och kan ha mindre teknisk erfarenhet.
+
+## Chefer behöver:
+
+Avsnittet riktar sig särskilt till chefer genom att erbjuda konkreta åtgärder de kan vidta i sin roll.
+
+Chefer ansvarar för att projekt levereras i tid, för intressenthantering och för fortsatt leverans av tjänsten.
+För detta är de helt beroende av såväl beslutsfattare som utvecklare och formgivare.
+De behöver skapa rätt kultur, samla rätt resurser och tillhandahålla rätt strukturer för att leverera utmärkta tjänster.
+
+## Utvecklare och formgivare behöver:
+
+Avsnittet riktar sig särskilt till utvecklare och formgivare genom att erbjuda dem konkreta åtgärder de kan vidta i sin roll.
+
+Utvecklare är vanligtvis mer tekniskt inriktade och har större inverkan på leveransen av tjänster än de tidigare grupperna.
+
+## Avgränsning
+
+Standarden för offentlig kod är inte avsedd att täcka enskilda driftsättningar av en kodbas.
+Det innebär att standarden inte talar om för de som driftsätter hur de ska anpassa sig till sin organisations lokala tekniska infrastruktur eller rättsliga ramverk.
+
+Även om standarden för offentlig kod hänvisar till flera standarder och har betydande överlappning med andra, är dess syfte att möjliggöra samarbete.
+Därför syftar den inte till att ersätta kvalitetsstandarder, som ISO 25000-serien, eller sådana som fokuserar på säkerhet, som [OpenSSF Best Practices Badge](https://github.com/coreinfrastructure/best-practices-badge), utan att samverka väl med dem.
+
+Och även om syftet innefattar att möjliggöra samarbete, garanterar det inte att en gemenskap uppstår.
+Det kräver fortfarande initiativkraft och ambition utöver att göra kodbasen samarbetsklar.

--- a/sv/standard-print.html
+++ b/sv/standard-print.html
@@ -1,0 +1,164 @@
+---
+---
+
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2019-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="assets/github-markdown.css">
+  <link rel="stylesheet" href="assets/print.css">
+  <title>{{ site.title }}</title>
+  <style>
+    /* Print specific */
+    @media print {
+      @page :left {
+        @top-left {
+          content: counter(page);
+        }
+      }
+      @page :right {
+        @top-right {
+          content: counter(page);
+        }
+      }
+    }
+  </style>
+</head>
+<body class="markdown-body">
+
+  <article id="section-first-page">
+    <p>Begäran om bidrag</p>
+    <h1 class="title">Standarden för offentlig kod</h1>
+
+    <ul class="first-page-audiences">
+      <lh>Vad offentlig kod är och hur den kan tillämpas, för:</lh>
+      <li id="first-page-public-policy-makers-what-you-need-to-do">Offentliga beslutsfattare</li>
+      <li id="first-page-managers-what-you-need-to-do">Chefer</li>
+      <li id="first-page-developers-and-designers-what-you-need-to-do">Utvecklare och formgivare</li>
+    </ul>
+
+    <img src="assets/hands-shake.svg" alt="handslag">
+
+    <p><strong>Utkast</strong><br/>Version <span class="standard-version">0.8.1</span></p>
+    <p><img src="/assets/cc-zero.svg" alt="Licensierad CC0" height="46"></p>
+    <p style="max-width:none">github.com/standard-for-public-code/standard-for-public-code</p>
+  </article>
+
+  <article id="section-authors">
+
+    {% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "AUTHORS.md" %}{{page.content | markdownify}}{% endif%}{% endfor %}
+
+  </article>
+
+  <article id="table-of-contents">
+
+    <h1>Innehållsförteckning</h1>
+
+    <ol>
+      <li><a href="#section-authors" class="table-of-contents">Upphovspersoner</a></li>
+      <li><a href="#section-readers-guide" class="table-of-contents">Läsanvisning</a></li>
+      <li><a href="#section-glossary" class="table-of-contents">Ordlista</a></li>
+      <li><a href="#section-criteria" class="table-of-contents">Kriterier</a>
+        {% assign sorted = site.pages | sort:"order" %}
+        <ol>
+        {% for page in sorted %}{% if page.dir == "/sv/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
+          <li><a href="#section-criteria-{{page.name}}" class="table-of-contents">{{page.title}}</a></li>{% endif%}
+        {% endif%}  {% endif%}{% endfor %}
+        </ol>
+      </li>
+      <li><a href="#section-contributing" class="table-of-contents">Bidragsguide</a></li>
+      <li><a href="#section-code-of-conduct" class="table-of-contents">Uppförandekod</a></li>
+      <li><a href="#section-governance" class="table-of-contents">Styrning</a></li>
+      <li><a href="#section-release-notes" class="table-of-contents">Versionshistorik</a></li>
+      <li><a href="#section-license" class="table-of-contents">Licens</a></li>
+    </ol>
+
+  </article>
+
+  <figure>
+    <img src="/assets/codebase.svg" alt="kodbas">
+  </figure>
+
+  <article id="section-readers-guide">
+
+    {% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "readers-guide.md" %}{{page.content | markdownify}}{% endif%}{% endfor %}
+
+  </article>
+
+  <article id="section-glossary">
+
+    {% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "glossary.md" %}{{page.content | markdownify}}{% endif%}{% endfor %}
+
+  </article>
+
+  <article id="section-criteria">
+    <h1>Kriterier</h1>
+    {% assign sorted = site.pages | sort:"order" %}
+    <ol>
+    {% for page in sorted %}{% if page.dir == "/sv/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
+      <li><a href="#section-criteria-{{page.name}}" class="table-of-contents">{{page.title}}</a></li>{% endif%}
+    {% endif%}  {% endif%}{% endfor %}
+    </ol>
+  </article>
+
+  <figure>
+    <img src="/assets/unlock.svg" alt="upplåst">
+  </figure>
+
+  {% assign sorted = site.pages | sort:"order" %}
+  {% for page in sorted %}{% if page.dir == "/sv/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
+    <article id="section-criteria-{{page.name}}">
+      {{page.content | markdownify}}
+    </article>{% endif%}
+  {% endif%}  {% endif%}{% endfor %}
+
+  <article id="section-contributing">
+
+    {% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "CONTRIBUTING.md" %}{{page.content | markdownify}}{% endif%}{% endfor %}
+
+  </article>
+
+  <figure>
+      <img src="/assets/collaborative-development.svg" alt="gemensam utveckling">
+    </figure>
+
+  <article id="section-code-of-conduct">
+
+    {% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "CODE_OF_CONDUCT.md" %}{{page.content | markdownify}}{% endif%}{% endfor %}
+
+  </article>
+
+  <figure>
+    <img src="/assets/collaboration.svg" alt="samarbete">
+  </figure>
+
+  <article id="section-governance">
+
+    {% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "GOVERNANCE.md" %}{{page.content | markdownify}}{% endif%}{% endfor %}
+
+  </article>
+
+  <figure>
+    <img src="/assets/eco-system.svg" alt="ekosystem">
+  </figure>
+
+  <article id="section-release-notes">
+
+    {% for page in site.pages %}{% if page.dir == "/sv/" and page.name == "RELEASE_NOTES.md" %}{{page.content | markdownify}}{% endif%}{% endfor %}
+
+  </article>
+
+  <article id="section-license">
+
+    <p>Licensen är det juridiska avtal som tillåter vem som helst att göra vad de vill med innehållet i hela dokumentet.</p>
+    <h1>CC0 1.0 Universal</h1>
+    <pre>{% include_relative LICENSE %}</pre>
+
+  </article>
+
+</body>
+</html>

--- a/sv/swedish_glossary.md
+++ b/sv/swedish_glossary.md
@@ -1,0 +1,155 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS
+---
+# Svensk terminologiordlista
+
+Ordlistan dokumenterar de svenska översättningsvalen för engelska termer som används i standarden för offentlig kod.
+Syftet är att säkerställa enhetlig terminologi genom hela översättningen och att underlätta för framtida översättare och granskare.
+
+## Grundbegrepp
+
+| Engelska | Svenska | Anmärkning |
+|----------|---------|------------|
+| code | kod | Avser både källkod och regelverk |
+| codebase | kodbas | |
+| source code | källkod | |
+| public code | offentlig kod | |
+| policy | regelverk | Omfattar lagar, förordningar, riktlinjer och styrdokument |
+| open source | fri- och öppen programvara, öppen källkod | Använd fri- och öppen programvara när programvaran som helhet avses |
+| open standard | öppen standard | |
+| software | programvara | |
+| standard | standard | |
+
+## Roller
+
+| Engelska | Svenska | Anmärkning |
+|----------|---------|------------|
+| public policy makers | offentliga beslutsfattare | |
+| managers | chefer | |
+| developers and designers | utvecklare och formgivare | |
+| contributor | bidragsgivare | |
+| reviewer | granskare | |
+| maintainer | underhållsansvarig | |
+| stakeholder | intressent | |
+| civil servant | tjänsteperson | Könsneutral form |
+| vendor | leverantör | |
+| end user | slutanvändare | |
+
+## Versionshantering
+
+| Engelska | Svenska | Anmärkning |
+|----------|---------|------------|
+| version control | versionshantering | |
+| repository | kodförråd | |
+| commit (substantiv) | incheckning | |
+| commit (verb) | checka in | |
+| commit message | incheckningsmeddelande | |
+| pull request | ändringsförfrågan | |
+| merge | sammanslå, sammanfoga, sammanslagning | |
+| branch | gren | |
+| branch protection | grenskydd | |
+| fork | avgrening | |
+| revision tag | revisionsetikett | |
+| release (substantiv) | utgåva | |
+| release (verb) | ge ut, släppa | |
+
+## Utveckling och drift
+
+| Engelska | Svenska | Anmärkning |
+|----------|---------|------------|
+| continuous integration | kontinuerlig integrering | behåller CI |
+| deploy, deployment | driftsätta, driftsättning | |
+| build-time | byggtid | |
+| runtime | körtid | |
+| bug | programfel | |
+| patch | programfix | |
+| linter | linter | |
+| configuration | konfiguration | |
+| module | modul | |
+| metadata | metadata | |
+| framework | ramverk | |
+| feature | funktion, funktionalitet | |
+| issue | ärende | |
+| issue tracker | ärendespårare | |
+| maintainability | underhållbarhet | |
+| technical debt | teknisk skuld | |
+
+## Samarbete och styrning
+
+| Engelska | Svenska | Anmärkning |
+|----------|---------|------------|
+| contribution | bidrag | |
+| review | granskning | |
+| governance | styrning | |
+| roadmap | framtidsplan | |
+| code of conduct | uppförandekod | |
+| community | gemenskap | |
+| feedback | återkoppling | |
+| steering team | styrgrupp | |
+| steering team member | styrgruppsledamot | |
+| consent (beslut) | samtycke | I styrningssammanhang |
+| voting | omröstning | |
+| impasse | dödläge | |
+
+## Licens och juridik
+
+| Engelska | Svenska | Anmärkning |
+|----------|---------|------------|
+| license | licens | |
+| open license | öppen licens | |
+| copyright | upphovsrätt | |
+| copyright notice | upphovsrättsmeddelande | |
+| public domain | allmän egendom | |
+| attribution | tillskrivning | |
+| vendor lock-in | leverantörsinlåsning | |
+| procurement | upphandling | |
+
+## Dokumentation
+
+| Engelska | Svenska | Anmärkning |
+|----------|---------|------------|
+| authors | upphovspersoner | |
+| readers guide | läsanvisning | |
+| glossary | ordlista | |
+| criteria | kriterier | |
+| requirement | krav | |
+| further reading | vidare läsning | |
+| table of contents | innehållsförteckning | |
+| version history | versionshistorik | |
+| changelog | ändringslogg | |
+| release notes | versionsinformation | Sammanfattning per utgåva |
+| release version | utgåveversion | |
+| overview | översikt | |
+
+## Kravnivånyckelord (RFC 2119)
+
+| Engelska | Svenska |
+|----------|---------|
+| MUST | MÅSTE |
+| MUST NOT | FÅR INTE |
+| REQUIRED | KRÄVS |
+| SHALL | SKALL |
+| SHALL NOT | SKALL INTE |
+| SHOULD | BÖR |
+| SHOULD NOT | BÖR INTE |
+| RECOMMENDED | REKOMMENDERAS |
+| MAY | FÅR |
+| OPTIONAL | VALFRITT |
+
+## Vanliga anglicismer
+
+| Anglicism | Rekommenderad ersättning | Anmärkning |
+|-----------|--------------------------|------------|
+| inkludera | innehålla, innefatta, ta med | Valet beror på sammanhanget |
+| inklusive | inbegripet, däribland | |
+| transparent | möjlig att granska, insyn | Adjektiv resp. substantiv |
+| transparens | insyn | |
+| proprietär | sluten | Om programvara, plattformar, tjänster |
+| kontext | sammanhang | |
+
+## Principer för översättningen
+
+* **Filnamn, mappnamn och YAML-frontmatter** översätts inte.
+* **Webbadresser och länkmål** behålls på engelska.
+* **Egennamn** på organisationer och projekt behålls på originalspråket.


### PR DESCRIPTION
The translation has been initially and fully done. There is still proofreading and discussions with fellow Swedes to do. So this PR is not merge ready, adding as a draft for now. It was machine/AI-translated, and then I had a first quick read, removing the worst warts. It is quite ok now. It is based on the devel-branch, as the original main still contains some refs to the old Foundation and such.

The build of the site can be viewed here for now and rebuilds on push to main:
 https://itiquette.github.io/community-translations-standard/sv/
Repo (preliminary): https://github.com/itiquette/community-translations-standard/tree/swedishtranslation

Note: After we are happy we the translation, we should discuss where it can be hosted long term.

@ixuz @Ainali I'm reaching out to you, and will give you full read/write/admin-rights to Swedish translation repo if you are interested in proofreading and so on, with the goal to get it merged in the end. Just let me know and I'll add you. No obligations though, If you don't have time I'll ask someone from the broader Swedish translation community if they would like to proofread. I will myself take a full read of it the coming the days. 

Note: in the repo can also be found an extra file, swedish_glossary.md which is the terms I used, and I have stuck to idiomatic Swedish FOSS-terms.
