### PR TITLE
Add link to Dutch translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2021-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
 
-This is a repository for unofficial translations of the [Standard for Public Code](https://standard.publiccode.net), provided by the community. 
+This is a repository for unofficial translations of the [Standard for Public Code](https://www.standardforpubliccode.org/), provided by the community. 
 A [Dutch translation](https://github.com/codefornl/community-translations-standard) is hosted separately by CodeforNL.
 
 [![pages-build-deployment](https://github.com/publiccodenet/community-translations-standard/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/publiccodenet/community-translations-standard/actions/workflows/pages/pages-build-deployment)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2021-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
 
-This is a repository for unofficial translations of the [Standard for Public Code](https://standard.publiccode.net), provided by the community. A [Dutch translation](https://github.com/codefornl/community-translations-standard) is hosted separately by CodeforNL.
+This is a repository for unofficial translations of the [Standard for Public Code](https://standard.publiccode.net), provided by the community. 
+A [Dutch translation](https://github.com/codefornl/community-translations-standard) is hosted separately by CodeforNL.
 
 [![pages-build-deployment](https://github.com/publiccodenet/community-translations-standard/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/publiccodenet/community-translations-standard/actions/workflows/pages/pages-build-deployment)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2021-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
 
-This is a repository for unofficial translations of the [Standard for Public Code](https://standard.publiccode.net), provided by the community.
+This is a repository for unofficial translations of the [Standard for Public Code](https://standard.publiccode.net), provided by the community. A [Dutch translation](https://github.com/codefornl/community-translations-standard) is hosted separately by CodeforNL.
 
 [![pages-build-deployment](https://github.com/publiccodenet/community-translations-standard/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/publiccodenet/community-translations-standard/actions/workflows/pages/pages-build-deployment)
 


### PR DESCRIPTION
Add a link to the NL translation so that someone coming here interested in Dutch can discover it already exists, despite there not being a folder for it here. 

It's mentioned on [translations.standardforpubliccode.net](https://translations.standardforpubliccode.org/), but not in this repo.

NB: merging #71 would make this obsolete. 